### PR TITLE
Add a build target for installing CKAN dependencies

### DIFF
--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -17,6 +17,9 @@
     <!--If the reference path isn't set, use the default steam location, but this will be incorrect in lots of cases-->
     <KSPRoot Condition = "('$(KSPRoot)' == '') And ($([MSBuild]::IsOsPlatform('Windows')))">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</KSPRoot>
     <KSPRoot Condition = "('$(KSPRoot)' == '') And ($([MSBuild]::IsOsPlatform('OSX')))">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</KSPRoot>
+
+    <!-- default CKAN compatibility versions -->
+    <CKANCompatibleVersions Condition="('$(CKANCompatibleVersions)' == '')">1.12 1.11 1.10 1.9 1.8</CKANCompatibleVersions>
   </PropertyGroup>
 
   <!--Import a props.user file if it exists, so that KSPRoot can be set globally for the whole mod if desired-->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -20,4 +20,9 @@
     </ItemGroup>
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(RepoRootPath)\$(BinariesOutputRelativePath)" />
   </Target>
+
+  <!-- Use CKAN to install mods for any references tagged with a CKAN ID-->
+  <Target Name="CKANInstall">
+    <Exec Command="CKAN install --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
+  </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -23,6 +23,6 @@
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN ID-->
   <Target Name="CKANInstall">
-    <Exec Command="CKAN install --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
+    <Exec Command="CKAN install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
   </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -23,6 +23,6 @@
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN ID-->
   <Target Name="CKANInstall">
-    <Exec Command="CKAN install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
+    <Exec Command="ckan install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
   </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -21,8 +21,9 @@
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(RepoRootPath)\$(BinariesOutputRelativePath)" />
   </Target>
 
-  <!-- Use CKAN to install mods for any references tagged with a CKAN ID-->
+  <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
   <Target Name="CKANInstall">
-    <Exec Command="ckan install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANID)" Condition=" '%(Reference.CKANID)' != '' "/>
+    <Exec Command="ckan compat add --headless --gamedir $(KSPROOT) $(CKANCompatibleVersions)" Condition=" '$(CKANCompatibleVersions)' != '' "/>
+    <Exec Command="ckan install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANIdentifier)" Condition=" '%(Reference.CKANIdentifier)' != '' "/>
   </Target>
 </Project>


### PR DESCRIPTION
For discussion on if this is the right path to take.

This allows describing CKAN dependencies from the csproj file. They can then be installed through msbuild like so:

`msbuild Shabby.sln -t:"CKANInstall"`

CKAN dependencies are marked as metadata under an assembly reference, like so:

```xml
    <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
      <HintPath>$(KSPRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
      <CKANID>Harmony2</CKANID>
    </Reference>
```

there's no way here to specify any mods that don't have dlls, which could be helpful for bundling dependencies in download packages. though I cant think of any non-dll mods you would want to bundle. It would be fairly easy to add a separate item list for such mods though. 