### PR TITLE
Fix compatible version list

### DIFF
--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -23,9 +23,9 @@
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
   <Target Name="CKANInstall">
     <ItemGroup>
-      <CKANCompatibleVersionItems Include="$(CKANCompatibleVersions)"/>
+      <CKANCompatibleVersionItems Include="$(CKANCompatibleVersions.Split(' '))"/>
     </ItemGroup>
-    <Exec Command="ckan compat add --headless --gamedir $(KSPROOT) %(CKANCompatibleVersionItems)" Condition=" '$(CKANCompatibleVersions)' != '' "/>
+    <Exec Command="ckan compat add --headless --gamedir $(KSPROOT) %(CKANCompatibleVersionItems.Identity)" Condition=" '$(CKANCompatibleVersions)' != '' "/>
     <Exec Command="ckan install --no-recommends --headless --gamedir $(KSPROOT) %(Reference.CKANIdentifier)" Condition=" '%(Reference.CKANIdentifier)' != '' "/>
   </Target>
 </Project>


### PR DESCRIPTION
msbuild documentation is really something else

turns out if you want to make it run multiple commands, you need %, and that means using a metadata value on the item, which they don't have. but turns out `.Identity` just gives you the value of the item. the % @ distinction seems needlessly confusing

also actually split the list :)