### PR TITLE
Support multi line identifiers argument

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,5 +10,7 @@ runs:
   steps:
     - name: Install Mods
       shell: bash
-      run: ckan install --headless --no-recommends ${{ runner.debug && '--verbose' }} ${{ inputs.dependency-identifiers }}
+      run: |
+        identifiers="${{ inputs.dependency-identifiers }}"
+        ckan install --headless --no-recommends ${{ runner.debug && '--verbose' }} $identifiers
 


### PR DESCRIPTION
Assign identifiers to a variable to convert multi line arguments into single line argument.
This is a re-introduction of this since it was removed in [this commit](https://github.com/KSPModdingLibs/KSPBuildTools/commit/3cc894c6a6624b5baaaff8cd37ac8f00aa86e85e#diff-6d8cc6283ab3a0a0d3db73624febe8bd91ec9ca7e229c25537ea2f471c2721bfL60-L61).

This allows for each dependency to be listed on a separate line when calling the workflow