### PR TITLE
Add target to generate version files

### DIFF
--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -75,7 +75,7 @@
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(Version)" Outputs="%(KSPVersionFile.destination)">
+  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)">
     <ReadLinesFromFile File="@(KSPVersionFile)" Condition="Exists('@(KSPVersionFile)')">
       <Output TaskParameter="Lines" ItemName="_JSONLines"/>
     </ReadLinesFromFile>
@@ -89,7 +89,7 @@
     <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'%(KSPVersionFile.Version)'" Condition="%(KSPVersionFile.Version) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'$(Version)'" Condition="%(KSPVersionFile.Version) == ''">
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'$(FileVersion)'" Condition="%(KSPVersionFile.Version) == ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
     <JsonPoke Content="$(_JSON)" Query="$.URL" RawValue="'%(KSPVersionFile.URL)'" Condition="%(KSPVersionFile.URL) != ''">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -79,28 +79,28 @@
     <PropertyGroup>
       <_JSON>{}</_JSON>
     </PropertyGroup>
-    <JsonPoke Content="$(_JSON)" Query="$.NAME" Value="%(VersionFile.Name)">
+    <JsonPoke Content="$(_JSON)" Query="$.NAME" RawValue="'%(VersionFile.Name)'">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" Value="%(VersionFile.Version)" Condition="%(VersionFile.Version) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'%(VersionFile.Version)'" Condition="%(VersionFile.Version) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" Value="$(Version)" Condition="%(VersionFile.Version) == ''">
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'$(Version)'" Condition="%(VersionFile.Version) == ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.URL" Value="%(VersionFile.URL)" Condition="%(VersionFile.URL) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.URL" RawValue="'%(VersionFile.URL)'" Condition="%(VersionFile.URL) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" Value="%(VersionFile.Download)" Condition="%(VersionFile.Download) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" RawValue="'%(VersionFile.Download)'" Condition="%(VersionFile.Download) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" Value="%(VersionFile.KSP_Version)" Condition="%(VersionFile.KSP_Version) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" RawValue="'%(VersionFile.KSP_Version)'" Condition="%(VersionFile.KSP_Version) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" Value="%(VersionFile.KSP_Version_Min)" Condition="%(VersionFile.KSP_Version_Min) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" RawValue="'%(VersionFile.KSP_Version_Min)'" Condition="%(VersionFile.KSP_Version_Min) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="%(VersionFile.KSP_Version_Max)" Condition="%(VersionFile.KSP_Version_Max) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="'%(VersionFile.KSP_Version_Max)'" Condition="%(VersionFile.KSP_Version_Max) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
     <Message Text="Out is $(_JSON)"/>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -76,8 +76,12 @@
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
   <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(VersionFile);$(Version)" Outputs="%(VersionFile.destination)">
+    <ReadLinesFromFile File="@(VersionFile)" Condition="Exists('@(VersionFile)')">
+      <Output TaskParameter="Lines" ItemName="_JSONLines"/>
+    </ReadLinesFromFile>
     <PropertyGroup>
-      <_JSON>{}</_JSON>
+      <_JSON>@(_JSONLines, '%0a')</_JSON>
+      <_JSON Condition="@(_JSONLines) == ''">{}</_JSON>
     </PropertyGroup>
     <JsonPoke Content="$(_JSON)" Query="$.NAME" RawValue="'%(VersionFile.Name)'">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
@@ -103,6 +107,9 @@
     <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="'%(VersionFile.KSP_Version_Max)'" Condition="%(VersionFile.KSP_Version_Max) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <Message Text="Out is $(_JSON)"/>
+    <WriteLinesToFile File="%(VersionFile.Destination)" Lines="$(_JSON)" Overwrite="true"/>
+
+    <Message Text="Writing JSON version file to %(VersionFile.Destination)"/>
+    <Message Text="Contents:%0a$(_JSON)" Importance="low"/>
   </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,6 +2,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' " Project="KSPCommon.props"/>
 
+  <!-- NuGet dependencies -->
+  <ItemGroup>
+    <!-- For GenerateKSPVersionFile -->
+    <PackageReference Include="JsonPoke" Version="1.2.0" Condition="@(VersionFile) != ''"/>
+  </ItemGroup>
+
   <!-- Pre/post build targets -->
   <Target Name="BeforeBuildScript" BeforeTargets="Build">
   </Target>
@@ -59,5 +65,44 @@
     <Message Text="@(RequiredExternalTool)" Importance="high"/>
   </Target>
 
+  <ItemDefinitionGroup>
+    <VersionFile>
+      <Name>$(SolutionName)</Name>
+      <KSP_Version>1.12</KSP_Version>
+      <KSP_Version_Min>1.8</KSP_Version_Min>
+      <KSP_Version_Max>1.12</KSP_Version_Max>
+    </VersionFile>
+  </ItemDefinitionGroup>
 
+  <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
+  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(VersionFile);$(Version)" Outputs="%(VersionFile.destination)">
+    <PropertyGroup>
+      <_JSON>{}</_JSON>
+    </PropertyGroup>
+    <JsonPoke Content="$(_JSON)" Query="$.NAME" Value="%(VersionFile.Name)">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" Value="%(VersionFile.Version)" Condition="%(VersionFile.Version) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" Value="$(Version)" Condition="%(VersionFile.Version) == ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.URL" Value="%(VersionFile.URL)" Condition="%(VersionFile.URL) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" Value="%(VersionFile.Download)" Condition="%(VersionFile.Download) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" Value="%(VersionFile.KSP_Version)" Condition="%(VersionFile.KSP_Version) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" Value="%(VersionFile.KSP_Version_Min)" Condition="%(VersionFile.KSP_Version_Min) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="%(VersionFile.KSP_Version_Max)" Condition="%(VersionFile.KSP_Version_Max) != ''">
+      <Output TaskParameter="Content" PropertyName="_JSON"/>
+    </JsonPoke>
+    <Message Text="Out is $(_JSON)"/>
+  </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -5,7 +5,7 @@
   <!-- NuGet dependencies -->
   <ItemGroup>
     <!-- For GenerateKSPVersionFile -->
-    <PackageReference Include="JsonPoke" Version="1.2.0" Condition="@(VersionFile) != ''"/>
+    <PackageReference Include="JsonPoke" Version="1.2.0" Condition="@(KSPVersionFile) != ''"/>
   </ItemGroup>
 
   <!-- Pre/post build targets -->
@@ -66,50 +66,50 @@
   </Target>
 
   <ItemDefinitionGroup>
-    <VersionFile>
+    <KSPVersionFile>
       <Name>$(SolutionName)</Name>
       <KSP_Version>1.12</KSP_Version>
       <KSP_Version_Min>1.8</KSP_Version_Min>
       <KSP_Version_Max>1.12</KSP_Version_Max>
-    </VersionFile>
+    </KSPVersionFile>
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(VersionFile);$(Version)" Outputs="%(VersionFile.destination)">
-    <ReadLinesFromFile File="@(VersionFile)" Condition="Exists('@(VersionFile)')">
+  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(Version)" Outputs="%(KSPVersionFile.destination)">
+    <ReadLinesFromFile File="@(KSPVersionFile)" Condition="Exists('@(KSPVersionFile)')">
       <Output TaskParameter="Lines" ItemName="_JSONLines"/>
     </ReadLinesFromFile>
     <PropertyGroup>
       <_JSON>@(_JSONLines, '%0a')</_JSON>
       <_JSON Condition="@(_JSONLines) == ''">{}</_JSON>
     </PropertyGroup>
-    <JsonPoke Content="$(_JSON)" Query="$.NAME" RawValue="'%(VersionFile.Name)'">
+    <JsonPoke Content="$(_JSON)" Query="$.NAME" RawValue="'%(KSPVersionFile.Name)'">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'%(VersionFile.Version)'" Condition="%(VersionFile.Version) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'%(KSPVersionFile.Version)'" Condition="%(KSPVersionFile.Version) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'$(Version)'" Condition="%(VersionFile.Version) == ''">
+    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'$(Version)'" Condition="%(KSPVersionFile.Version) == ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.URL" RawValue="'%(VersionFile.URL)'" Condition="%(VersionFile.URL) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.URL" RawValue="'%(KSPVersionFile.URL)'" Condition="%(KSPVersionFile.URL) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" RawValue="'%(VersionFile.Download)'" Condition="%(VersionFile.Download) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" RawValue="'%(KSPVersionFile.Download)'" Condition="%(KSPVersionFile.Download) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" RawValue="'%(VersionFile.KSP_Version)'" Condition="%(VersionFile.KSP_Version) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" RawValue="'%(KSPVersionFile.KSP_Version)'" Condition="%(KSPVersionFile.KSP_Version) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" RawValue="'%(VersionFile.KSP_Version_Min)'" Condition="%(VersionFile.KSP_Version_Min) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" RawValue="'%(KSPVersionFile.KSP_Version_Min)'" Condition="%(KSPVersionFile.KSP_Version_Min) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="'%(VersionFile.KSP_Version_Max)'" Condition="%(VersionFile.KSP_Version_Max) != ''">
+    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="'%(KSPVersionFile.KSP_Version_Max)'" Condition="%(KSPVersionFile.KSP_Version_Max) != ''">
       <Output TaskParameter="Content" PropertyName="_JSON"/>
     </JsonPoke>
-    <WriteLinesToFile File="%(VersionFile.Destination)" Lines="$(_JSON)" Overwrite="true"/>
+    <WriteLinesToFile File="%(KSPVersionFile.Destination)" Lines="$(_JSON)" Overwrite="true"/>
 
-    <Message Text="Writing JSON version file to %(VersionFile.Destination)"/>
+    <Message Text="Writing JSON version file to %(KSPVersionFile.Destination)"/>
     <Message Text="Contents:%0a$(_JSON)" Importance="low"/>
   </Target>
 </Project>


### PR DESCRIPTION
How to use:

Declare one or more `VersionFile` items in your csproj

```xml
  <ItemGroup>
    <VersionFile Include=".">
      <Destination>file1.version</Destination>
      <Name>MyCoolMod</Name>
    </VersionFile>
    <VersionFile Include="myversion.json"> <!-- included file is used as a base for the version file, if more information is desired to be included -->
      <Destination>file2.version</Destination>
      <Version>2.0.0</Version>
    </VersionFile>
  </ItemGroup>
```
Version and Name are auto-populated. if they aren't provided
  
Results in a version file being generated like so
```json
{
  "NAME": "MyCoolMod",
  "VERSION": "0.3.1",
  "KSP_VERSION": "1.12",
  "KSP_VERSION_MIN": "1.8",
  "KSP_VERSION_MAX": "1.12"
}
```

I think this goes nicely with the proposed git-based-versioning approach (#13) (will add that in with a different PR) 

Up for bikeshedding:
- should the KSP version and min/max get defaults?
- more specific name than `VersionFile` like `KSPVersionFile`?