### PR TITLE
Add functionality to generate KSP assembly attributes

### DIFF
--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -61,55 +61,10 @@
   </Target>
 
   <!--
-  Gets version info from Git, or falls back to 0.0.0 if this fails.
-  This will not work if you have any hyphens in your tag names. blame Git
-
-  Populates the following properties:
-    GitTag: The most recent tag in the repo
-    GitHeight: The number of commits since that tag
-    GitCommit: The most recent git commit hash in the repo
-    Version: (MSBuild wellknown property) The calculated version.
-      Equal to GitTag but with the patch number incremented if GitHeight is not 0
-    Build: The build number. Equal to GitHeight
+  Generate the KSPAssembly attribute based on the FileVersion property
   -->
-  <Target Name="GetVersionFromGit" BeforeTargets="PrepareForBuild" Condition="$(GetVersionFromGit) == 'true'">
-    <PropertyGroup>
-      <!-- Fallback values -->
-      <Version>0.0.0</Version>
-      <Build>0</Build>
-    </PropertyGroup>
-    <Exec Command="git describe --tags --long" ConsoleToMSBuild="true"
-          IgnoreStandardErrorWarningFormat="true" IgnoreExitCode="true"
-          EchoOff="true" WorkingDirectory="$(RepoRootPath)">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_GitDescribe"/>
-      <Output TaskParameter="ExitCode" PropertyName="_GitDescribeExit"/>
-    </Exec>
-    <PropertyGroup Condition="$(_GitDescribeExit) == 0">
-      <GitTag>$(_GitDescribe.Split('-')[0])</GitTag>
-      <GitHeight>$(_GitDescribe.Split('-')[1])</GitHeight>
-      <GitCommit>$(_GitDescribe.Split('-')[2])</GitCommit>
-      <_VersionMajor>$(GitTag.Split('.')[0])</_VersionMajor>
-      <_VersionMinor>$(GitTag.Split('.')[1])</_VersionMinor>
-      <_VersionPatch>$(GitTag.Split('.')[2])</_VersionPatch>
-      <_VersionPatch Condition="$(GitHeight) != '0'">$([MSBuild]::Add($(_VersionPatch), 1))</_VersionPatch>
-      <Version>$(_VersionMajor).$(_VersionMinor).$(_VersionPatch)</Version>
-      <Build>$(GitHeight)</Build>
-    </PropertyGroup>
-    <PropertyGroup>
-      <AssemblyVersion>$(Version).$(Build)</AssemblyVersion>
-    </PropertyGroup>
-    <Message Text="Calculated version from git is $(Version)" Condition="$(_GitDescribeExit) == 0"/>
-  </Target>
-
-
-  <!--
-  Generate the KSPAssembly attribute based on the Version property
-  -->
-  <ItemGroup>
-    <GenerateKSPAssemblyAttributeDependsOn Include='GetVersionFromGit' Condition="$(GetVersionFromGit) == 'true'"/>
-  </ItemGroup>
   <Target Name="GenerateKSPAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition="$(GenerateKSPAssemblyAttribute)" DependsOnTargets="$(GenerateKSPAssemblyAttributeDependsOn)">
+          Condition="$(GenerateKSPAssemblyAttribute)">
     <ItemGroup>
       <AssemblyAttribute Include="KSPAssembly">
         <_Parameter1>$(AssemblyName)</_Parameter1>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -103,4 +103,56 @@
   </Target>
 
 
+  <!--
+  Generate the KSPAssembly attribute based on the Version property
+  -->
+  <ItemGroup>
+    <GenerateKSPAssemblyAttributeDependsOn Include='GetVersionFromGit' Condition="$(GetVersionFromGit)"/>
+  </ItemGroup>
+  <Target Name="GenerateKSPAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition="$(GenerateKSPAssemblyAttribute)" DependsOnTargets="$(GenerateKSPAssemblyAttributeDependsOn)">
+    <ItemGroup>
+      <AssemblyAttribute Include="KSPAssembly">
+        <_Parameter1>$(AssemblyName)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
+        <_Parameter2>$(Version.Split('.')[0])</_Parameter2>
+        <_Parameter2_TypeName>System.Int32</_Parameter2_TypeName>
+        <_Parameter3>$(Version.Split('.')[1])</_Parameter3>
+        <_Parameter3_TypeName>System.Int32</_Parameter3_TypeName>
+        <_Parameter4>$(Version.Split('.')[2])</_Parameter4>
+        <_Parameter4_TypeName>System.Int32</_Parameter4_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
+  <!--
+  Generate the KSPAssemblyDependency attributes based on input references
+
+  Reference items must have a CKANIdentifier or a KSPAssemblyName.
+  KSPAssemblyVersion can be optionally specified.
+    Otherwise CKANVersion is used.
+    Otherwise 0.0.0 is used (no minimum version)
+  -->
+  <Target Name="GenerateKSPAssemblyDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition="$(GenerateKSPAssemblyDependencyAttributes) == 'true'">
+    <ItemGroup>
+      <Reference Update="%(Reference.identity)" Condition="'%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != ''">
+        <KSPAssemblyName Condition="%(Reference.KSPAssemblyName) == ''">$([System.String]::Copy('%(Reference.identity)').Split(',')[0])</KSPAssemblyName>
+        <KSPAssemblyVersion Condition="%(Reference.KSPAssemblyVersion) == ''">%(Reference.CKANVersion)</KSPAssemblyVersion>
+        <KSPAssemblyVersion Condition="%(Reference.KSPAssemblyVersion) == ''">0.0.0</KSPAssemblyVersion>
+      </Reference>
+    </ItemGroup>
+    <ItemGroup>
+      <AssemblyAttribute Include="KSPAssemblyDependency" Condition="%(Reference.KSPAssemblyName) != ''">
+        <_Parameter1>%(Reference.KSPAssemblyName)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
+        <_Parameter2>$([System.String]::Copy('%(Reference.KSPAssemblyVersion)').Split('.')[0])</_Parameter2>
+        <_Parameter2_TypeName>System.Int32</_Parameter2_TypeName>
+        <_Parameter3>$([System.String]::Copy('%(Reference.KSPAssemblyVersion)').Split('.')[1])</_Parameter3>
+        <_Parameter3_TypeName>System.Int32</_Parameter3_TypeName>
+        <_Parameter4>$([System.String]::Copy('%(Reference.KSPAssemblyVersion)').Split('.')[2])</_Parameter4>
+        <_Parameter4_TypeName>System.Int32</_Parameter4_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -37,7 +37,7 @@
     <ItemGroup>
       <!-- Not using `ckan compat set` because as of 2024-08-16 it is still only available in the dev branch -->
       <_CKANCommands Include="compat add --gamedir &quot;$(KSPROOT)&quot; %(_CKANCompatibleVersionItems.Identity)"
-                    Condition=" '$(CKANCompatibleVersions)' != '' "/>
+                     Condition=" '$(CKANCompatibleVersions)' != '' "/>
 
       <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPROOT)&quot; $(_CKANDependencyList)"/>
     </ItemGroup>
@@ -73,7 +73,12 @@
     Version: (MSBuild wellknown property) The calculated version
     Build: The build number. Equal to GitHeight
   -->
-  <Target Name="GetVersionFromGit" BeforeTargets="BeforeBuild" Condition="$(PopulateVersionFromGit)">
+  <Target Name="GetVersionFromGit" BeforeTargets="BeforeBuild" Condition="$(GetVersionFromGit) == 'true'">
+    <PropertyGroup>
+      <!-- Fallback values -->
+      <Version>0.0.0</Version>
+      <Build>0</Build>
+    </PropertyGroup>
     <Exec Command="git describe --tags --long" ConsoleToMSBuild="true"
           IgnoreStandardErrorWarningFormat="true" IgnoreExitCode="true"
           EchoOff="true" WorkingDirectory="$(RepoRootPath)">
@@ -84,21 +89,15 @@
       <GitTag>$(_GitDescribe.Split('-')[0])</GitTag>
       <GitHeight>$(_GitDescribe.Split('-')[1])</GitHeight>
       <GitCommit>$(_GitDescribe.Split('-')[2])</GitCommit>
-      <VersionMajor>$(GitTag.Split('.')[0])</VersionMajor>
-      <VersionMinor>$(GitTag.Split('.')[1])</VersionMinor>
-      <VersionPatch>$(GitTag.Split('.')[2])</VersionPatch>
-      <VersionPatch Condition="$(GitHeight) != '0'">$([MSBuild]::Add($(VersionPatch), 1))</VersionPatch>
+      <_VersionMajor>$(GitTag.Split('.')[0])</_VersionMajor>
+      <_VersionMinor>$(GitTag.Split('.')[1])</_VersionMinor>
+      <_VersionPatch>$(GitTag.Split('.')[2])</_VersionPatch>
+      <_VersionPatch Condition="$(GitHeight) != '0'">$([MSBuild]::Add($(_VersionPatch), 1))</_VersionPatch>
+      <Version>$(_VersionMajor).$(_VersionMinor).$(_VersionPatch)</Version>
       <Build>$(GitHeight)</Build>
     </PropertyGroup>
-    <PropertyGroup Condition="$(_GitDescribeExit) != 0">
-      <!-- Git describe failed, so fallback to a backup version-->
-      <VersionMajor>0</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <VersionPatch>0</VersionPatch>
-      <Build>0</Build>
-    </PropertyGroup>
     <PropertyGroup>
-      <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch)</Version>
+      <AssemblyVersion>$(Version).$(Build)</AssemblyVersion>
     </PropertyGroup>
     <Message Text="Calculated version from git is $(Version)" Condition="$(_GitDescribeExit) == 0"/>
   </Target>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -106,7 +106,7 @@
   Generate the KSPAssembly attribute based on the Version property
   -->
   <ItemGroup>
-    <GenerateKSPAssemblyAttributeDependsOn Include='GetVersionFromGit' Condition="$(GetVersionFromGit)"/>
+    <GenerateKSPAssemblyAttributeDependsOn Include='GetVersionFromGit' Condition="$(GetVersionFromGit) == 'true'"/>
   </ItemGroup>
   <Target Name="GenerateKSPAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
           Condition="$(GenerateKSPAssemblyAttribute)" DependsOnTargets="$(GenerateKSPAssemblyAttributeDependsOn)">
@@ -114,11 +114,11 @@
       <AssemblyAttribute Include="KSPAssembly">
         <_Parameter1>$(AssemblyName)</_Parameter1>
         <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
-        <_Parameter2>$(Version.Split('.')[0])</_Parameter2>
+        <_Parameter2>$(FileVersion.Split('.')[0])</_Parameter2>
         <_Parameter2_TypeName>System.Int32</_Parameter2_TypeName>
-        <_Parameter3>$(Version.Split('.')[1])</_Parameter3>
+        <_Parameter3>$(FileVersion.Split('.')[1])</_Parameter3>
         <_Parameter3_TypeName>System.Int32</_Parameter3_TypeName>
-        <_Parameter4>$(Version.Split('.')[2])</_Parameter4>
+        <_Parameter4>$(FileVersion.Split('.')[2])</_Parameter4>
         <_Parameter4_TypeName>System.Int32</_Parameter4_TypeName>
       </AssemblyAttribute>
     </ItemGroup>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -59,5 +59,49 @@
     <Message Text="@(RequiredExternalTool)" Importance="high"/>
   </Target>
 
+  <!--
+  Gets version info from Git, or falls back to 0.0.0 if this fails.
+  This will not work if you have any hyphens in your tag names. blame Git
+
+  Populates the following properties:
+    GitTag: The most recent tag in the repo
+    GitHeight: The number of commits since that tag
+    GitCommit: The most recent git commit hash in the repo
+    VersionMajor: The major SemVer version number. Taken directly from the tag
+    VersionMinor: The minor SemVer version number. Taken directly from the tag
+    VersionPatch: The patch SemVer version number. Taken from the tag, and incremented by 1 if GitHeight != 0
+    Version: (MSBuild wellknown property) The calculated version
+    Build: The build number. Equal to GitHeight
+  -->
+  <Target Name="GetVersionFromGit" BeforeTargets="BeforeBuild" Condition="$(PopulateVersionFromGit)">
+    <Exec Command="git describe --tags --long" ConsoleToMSBuild="true"
+          IgnoreStandardErrorWarningFormat="true" IgnoreExitCode="true"
+          EchoOff="true" WorkingDirectory="$(RepoRootPath)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitDescribe"/>
+      <Output TaskParameter="ExitCode" PropertyName="_GitDescribeExit"/>
+    </Exec>
+    <PropertyGroup Condition="$(_GitDescribeExit) == 0">
+      <GitTag>$(_GitDescribe.Split('-')[0])</GitTag>
+      <GitHeight>$(_GitDescribe.Split('-')[1])</GitHeight>
+      <GitCommit>$(_GitDescribe.Split('-')[2])</GitCommit>
+      <VersionMajor>$(GitTag.Split('.')[0])</VersionMajor>
+      <VersionMinor>$(GitTag.Split('.')[1])</VersionMinor>
+      <VersionPatch>$(GitTag.Split('.')[2])</VersionPatch>
+      <VersionPatch Condition="$(GitHeight) != '0'">$([MSBuild]::Add($(VersionPatch), 1))</VersionPatch>
+      <Build>$(GitHeight)</Build>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(_GitDescribeExit) != 0">
+      <!-- Git describe failed, so fallback to a backup version-->
+      <VersionMajor>0</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <VersionPatch>0</VersionPatch>
+      <Build>0</Build>
+    </PropertyGroup>
+    <PropertyGroup>
+      <Version>$(VersionMajor).$(VersionMinor).$(VersionPatch)</Version>
+    </PropertyGroup>
+    <Message Text="Calculated version from git is $(Version)" Condition="$(_GitDescribeExit) == 0"/>
+  </Target>
+
 
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -72,7 +72,7 @@
       Equal to GitTag but with the patch number incremented if GitHeight is not 0
     Build: The build number. Equal to GitHeight
   -->
-  <Target Name="GetVersionFromGit" BeforeTargets="BeforeBuild" Condition="$(GetVersionFromGit) == 'true'">
+  <Target Name="GetVersionFromGit" BeforeTargets="PrepareForBuild" Condition="$(GetVersionFromGit) == 'true'">
     <PropertyGroup>
       <!-- Fallback values -->
       <Version>0.0.0</Version>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -24,7 +24,8 @@
   <Target Name="CKANInstall" BeforeTargets="_GenerateRestoreProjectSpec;Restore">
     <ItemGroup>
       <_CKANCompatibleVersionItems Include="$(CKANCompatibleVersions.Split(' '))"/>
-      <_CKANDependency Include="%(Reference.CKANIdentifier)"/>
+      <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="%(Reference.CKANVersion) == ''"/>
+      <_CKANDependency Include="%(Reference.CKANIdentifier)=%(Reference.CKANVersion)" Condition="%(Reference.CKANVersion) != ''"/>
       <_CKANDependency Include="@(CKANDependency)"/>
     </ItemGroup>
 

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -21,34 +21,37 @@
   </Target>
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
-  <Target Name="CKANInstall" BeforeTargets="_GenerateRestoreProjectSpec;Restore" Inputs="@(Reference)" Outputs="$(KSPRoot)/CKAN/registry.json">
+  <Target Name="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore">
+    <Message Text="IntermediateOutputPath: $(Test)"/>
     <ItemGroup>
       <_CKANCompatibleVersionItems Include="$(CKANCompatibleVersions.Split(' '))"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="%(Reference.CKANVersion) == ''"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)=%(Reference.CKANVersion)" Condition="%(Reference.CKANVersion) != ''"/>
       <_CKANDependency Include="@(CKANDependency)"/>
     </ItemGroup>
-
     <PropertyGroup>
-      <_TempStagingFolder>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</_TempStagingFolder>
-      <_CKANCommandFile>$(_TempStagingFolder)/ckan_commands.txt</_CKANCommandFile>
-      <_CKANDependencyList>@(_CKANDependency, ' ')</_CKANDependencyList>
+      <CKANDependencyList>@(_CKANDependency, ' ')</CKANDependencyList>
+      <CKANCommandFile>$(IntermediateOutputPath)CKANCommands</CKANCommandFile>
     </PropertyGroup>
-
     <ItemGroup>
       <!-- Not using `ckan compat set` because as of 2024-08-16 it is still only available in the dev branch -->
       <_CKANCommands Include="compat add --gamedir &quot;$(KSPROOT)&quot; %(_CKANCompatibleVersionItems.Identity)"
                      Condition=" '$(CKANCompatibleVersions)' != '' "/>
 
-      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPROOT)&quot; $(_CKANDependencyList)"/>
+      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPROOT)&quot; $(CKANDependencyList)" Condition="$(CKANDependencyList) != ''"/>
     </ItemGroup>
-
-    <Message Text="Writing CKAN commands to $(_CKANCommandFile)"/>
+    <Message Text="Writing CKAN commands to $(CKANCommandFile)"/>
     <Message Text="@(_CKANCommands, '%0a')" Importance="Low"/>
-    <WriteLinesToFile File="$(_CKANCommandFile)" Lines="@(_CKANCommands)"/>
-    <Exec Command="cat '$(_CKANCommandFile)' | ckan prompt --headless"
-          Condition="'$(_CKANDependencyList)' != ''"/>
-    <RemoveDir Directories="$(_TempStagingFolder)"/>
+    <WriteLinesToFile File="$(CKANCommandFile)" Lines="@(_CKANCommands)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
+  </Target>
+
+  <!-- Execute generated CKAN command list -->
+  <Target Name="CKANInstall" DependsOnTargets="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore" Inputs="$(CKANCommandFile)" Outputs="$(KSPRoot)/CKAN/registry.json">
+    <Exec Command="cat '$(CKANCommandFile)' | ckan prompt --headless" Condition="'$(CKANDependencyList)' != ''"/>
+  </Target>
+
+  <Target Name="CKANClean" AfterTargets="Clean">
+    <Delete Files="$(IntermediateOutputPath)CKANCommands"/>
   </Target>
 
   <!--  For use like so: `msbuild -t:"GetRequiredExternalTools" -verbosity:minimal -nologo`, then pipe into your destination of choice -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -21,7 +21,7 @@
   </Target>
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
-  <Target Name="CKANInstall" BeforeTargets="_GenerateRestoreProjectSpec;Restore">
+  <Target Name="CKANInstall" BeforeTargets="_GenerateRestoreProjectSpec;Restore" Inputs="@(Reference)" Outputs="$(KSPRoot)/CKAN/registry.json">
     <ItemGroup>
       <_CKANCompatibleVersionItems Include="$(CKANCompatibleVersions.Split(' '))"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="%(Reference.CKANVersion) == ''"/>
@@ -68,10 +68,8 @@
     GitTag: The most recent tag in the repo
     GitHeight: The number of commits since that tag
     GitCommit: The most recent git commit hash in the repo
-    VersionMajor: The major SemVer version number. Taken directly from the tag
-    VersionMinor: The minor SemVer version number. Taken directly from the tag
-    VersionPatch: The patch SemVer version number. Taken from the tag, and incremented by 1 if GitHeight != 0
-    Version: (MSBuild wellknown property) The calculated version
+    Version: (MSBuild wellknown property) The calculated version.
+      Equal to GitTag but with the patch number incremented if GitHeight is not 0
     Build: The build number. Equal to GitHeight
   -->
   <Target Name="GetVersionFromGit" BeforeTargets="BeforeBuild" Condition="$(GetVersionFromGit) == 'true'">

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Here's an example from [kOS](https://github.com/KSP-KOS/KOS/blob/22808556c090ebe
 
 Note that `KSPCommon.targets` makes use of `KSPCommon.props` for advanced users, which sets all the below properties but does not include the build targets.  If you only want the properties and not the targets, you can use `KSPCommon.props` instead.
 
+### Versioning
+
+[MinVer](https://github.com/adamralph/minver) is recommended for versioning mods. KSPCommon.targets will use the generated version correctly.
+
 ### Customization
 
 Properties can be customized at several points:
@@ -82,10 +86,6 @@ This property should be set to the root directory of your KSP install.  If it is
 Default value: `1.12 1.11 1.10 1.9 1.8`
 
 Used by the `CKANInstall` target to set additional KSP versions to treat as compatible when installing dependencies.
-
-#### `GetVersionFromGit`
-
-If set to `true`, the `Version` property will be automatically populated from your git tags. Tags must be in SemVer format. If the current commit is not tagged, it will use the most recent tag with the patch number incremented by 1. The Version attribute will automatically be added to your assembly's `AssemblyVersionAttribute`, there is no need to have that in an assemblyinfo.cs file.
 
 #### `GenerateKSPAssemblyAttribute`
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Default value: `1.12 1.11 1.10 1.9 1.8`
 
 Used by the `CKANInstall` target to set additional KSP versions to treat as compatible when installing dependencies.
 
+#### `GetVersionFromGit`
+
+If set to `true`, the `Version` property will be automatically populated from your git tags. Tags must be in SemVer format. If the current commit is not tagged, it will use the most recent tag with the patch number incremented by 1. The Version attribute will automatically be added to your assembly's `AssemblyVersionAttribute`, there is no need to have that in an assemblyinfo.cs file.
+
+#### `GenerateKSPAssemblyAttribute`
+
+If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.
+
+#### `GenerateKSPAssemblyDependencyAttributes`
+
+If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. See [Referencing Dependencies](#referencing-dependencies) below.
+
 ### Referencing Dependencies
 
 Referencing assemblies (DLLs) from other mods should be done with a HintPath relative to `$(KSPRoot)`.  These should be placed *after* importing `KSPCommon.targets` so that `$(KSPRoot)` will be defined.  In addition, you can include the CKAN identifier of the mod to make it installable when restoring the project. Dependencies should have the private flag set to false, unless they are intended to be included alongside the main dll.


### PR DESCRIPTION
Adds targets enabled by the following properties:

#### `GenerateKSPAssemblyAttribute`

If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.

#### `GenerateKSPAssemblyDependencyAttributes`

If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`.

Also fixed up the CKAN install stuff so it only runs when absolutely necessary

## Up for Bikeshedding:
- Should any of these be opt-out instead of opt-in?