### PR TITLE
Drop JsonPoke requirement for version-file generation

### DIFF
--- a/KSPBuildTools.csproj
+++ b/KSPBuildTools.csproj
@@ -10,10 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JsonPoke" Version="1.2.0">
-      <PrivateAssets>None</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,12 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
-  <!-- NuGet dependencies -->
-  <ItemGroup>
-    <!-- For GenerateKSPVersionFile -->
-    <PackageReference Include="JsonPoke" Version="1.2.0" Condition="@(KSPVersionFile) != ''"/>
-  </ItemGroup>
-
   <!--Custom Targets-->
 
   <Target Name="CheckForKSPRoot" BeforeTargets="ResolveReferences">
@@ -132,28 +126,21 @@
     </ItemGroup>
   </Target>
 
-  <!-- Version file handling -->
-
+  <!-- Version file configuration -->
   <ItemDefinitionGroup>
     <KSPVersionFile>
       <Name/>
-      <Url/>
+      <URL/>
       <Download/>
-      <KspVersion>1.12</KspVersion>
-      <KspVersionMin>1.8</KspVersionMin>
-      <KspVersionMax>1.12</KspVersionMax>
-      <Destination></Destination>
+      <KSP_Version>1.12</KSP_Version>
+      <KSP_Version_Min>1.8</KSP_Version_Min>
+      <KSP_Version_Max>1.12</KSP_Version_Max>
+      <Destination/>
     </KSPVersionFile>
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)">
-
-    <!-- Add back-compat support. Check if KSPVersionFile has these -->
-<!--     <KSP_Version>1.12</KSP_Version>
-    <KSP_Version_Min>1.8</KSP_Version_Min>
-    <KSP_Version_Max>1.12</KSP_Version_Max> -->
-
+  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.Destination)">
     <ItemGroup>
       <KSPVersionFile Update="@(KSPVersionFile)">
         <Name Condition="%(KSPVersionFile.Name) == ''">$(ProjectName)</Name>
@@ -166,11 +153,11 @@
       <JsonLine Include="{"/>
       <JsonLine Include="&quot;NAME&quot;: &quot;%(KSPVersionFile.Name)&quot;," Indent="  "/>
       <JsonLine Include="&quot;VERSION&quot;: &quot;%(KSPVersionFile.Version)&quot;," Indent="  "/>
-      <JsonLine Include="&quot;URL&quot;: &quot;%(KSPVersionFile.Url)&quot;," Indent="  "/>
-      <JsonLine Include="&quot;DOWNLOAD&quot;: &quot;%(KSPVersionFile.Download)&quot;," Indent="  "/>
-      <JsonLine Include="&quot;KSP_VERSION&quot;: &quot;%(KSPVersionFile.KspVersion)&quot;," Indent="  "/>
-      <JsonLine Include="&quot;KSP_VERSION_MIN&quot;: &quot;%(KSPVersionFile.KspVersionMin)&quot;," Indent="  "/>
-      <JsonLine Include="&quot;KSP_VERSION_MAX&quot;: &quot;%(KSPVersionFile.KspVersionMax)&quot;" Indent="  "/>
+      <JsonLine Include="&quot;URL&quot;: &quot;%(KSPVersionFile.URL)&quot;," Indent="  " Condition="%(KSPVersionFile.URL) != ''" />
+      <JsonLine Include="&quot;DOWNLOAD&quot;: &quot;%(KSPVersionFile.Download)&quot;," Indent="  " Condition="%(KSPVersionFile.Download) != ''" />
+      <JsonLine Include="&quot;KSP_VERSION&quot;: &quot;%(KSPVersionFile.KSP_Version)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;KSP_VERSION_MIN&quot;: &quot;%(KSPVersionFile.KSP_Version_Min)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;KSP_VERSION_MAX&quot;: &quot;%(KSPVersionFile.KSP_Version_Max)&quot;" Indent="  "/>
       <JsonLine Include="}"/>
     </ItemGroup>
 
@@ -189,6 +176,5 @@
             Encoding="UTF-8" />
 
     <Message Text="Writing KSP JSON version file to %(KSPVersionFile.Destination)"/>
-    <Message Text="Contents:%0a$(_JSON)" Importance="low"/>
   </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -132,53 +132,63 @@
     </ItemGroup>
   </Target>
 
+  <!-- Version file handling -->
+
   <ItemDefinitionGroup>
     <KSPVersionFile>
-      <KSP_Version>1.12</KSP_Version>
-      <KSP_Version_Min>1.8</KSP_Version_Min>
-      <KSP_Version_Max>1.12</KSP_Version_Max>
+      <Name/>
+      <Url/>
+      <Download/>
+      <KspVersion>1.12</KspVersion>
+      <KspVersionMin>1.8</KspVersionMin>
+      <KspVersionMax>1.12</KspVersionMax>
+      <Destination></Destination>
     </KSPVersionFile>
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
   <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)">
+
+    <!-- Add back-compat support. Check if KSPVersionFile has these -->
+<!--     <KSP_Version>1.12</KSP_Version>
+    <KSP_Version_Min>1.8</KSP_Version_Min>
+    <KSP_Version_Max>1.12</KSP_Version_Max> -->
+
     <ItemGroup>
       <KSPVersionFile Update="@(KSPVersionFile)">
         <Name Condition="%(KSPVersionFile.Name) == ''">$(ProjectName)</Name>
         <Version Condition="%(KSPVersionFile.Version) == ''">$(FileVersion.Split(`.`)[0]).$(FileVersion.Split(`.`)[1]).$(FileVersion.Split(`.`)[2])</Version>
       </KSPVersionFile>
     </ItemGroup>
-    <ReadLinesFromFile File="%(KSPVersionFile.identity)" Condition="Exists('@(KSPVersionFile)')">
-      <Output TaskParameter="Lines" ItemName="_JSONLines"/>
-    </ReadLinesFromFile>
-    <PropertyGroup>
-      <_JSON>@(_JSONLines, '%0a')</_JSON>
-      <_JSON Condition="@(_JSONLines) == ''">{}</_JSON>
-    </PropertyGroup>
-    <JsonPoke Content="$(_JSON)" Query="$.NAME" RawValue="'%(KSPVersionFile.Name)'">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.VERSION" RawValue="'%(KSPVersionFile.Version)'">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.URL" RawValue="'%(KSPVersionFile.URL)'" Condition="%(KSPVersionFile.URL) != ''">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.DOWNLOAD" RawValue="'%(KSPVersionFile.Download)'" Condition="%(KSPVersionFile.Download) != ''">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION" RawValue="'%(KSPVersionFile.KSP_Version)'" Condition="%(KSPVersionFile.KSP_Version) != ''">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MIN" RawValue="'%(KSPVersionFile.KSP_Version_Min)'" Condition="%(KSPVersionFile.KSP_Version_Min) != ''">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <JsonPoke Content="$(_JSON)" Query="$.KSP_VERSION_MAX" Value="'%(KSPVersionFile.KSP_Version_Max)'" Condition="%(KSPVersionFile.KSP_Version_Max) != ''">
-      <Output TaskParameter="Content" PropertyName="_JSON"/>
-    </JsonPoke>
-    <WriteLinesToFile File="%(KSPVersionFile.Destination)" Lines="$(_JSON)" Overwrite="true"/>
 
-    <Message Text="Writing JSON version file to %(KSPVersionFile.Destination)"/>
+    <!-- List of JSON lines to write. MSBuild doesn't play well with spaces, an Indent property is used to handle per-line indention -->
+    <ItemGroup>
+      <JsonLine Include="{"/>
+      <JsonLine Include="&quot;NAME&quot;: &quot;%(KSPVersionFile.Name)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;VERSION&quot;: &quot;%(KSPVersionFile.Version)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;URL&quot;: &quot;%(KSPVersionFile.Url)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;DOWNLOAD&quot;: &quot;%(KSPVersionFile.Download)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;KSP_VERSION&quot;: &quot;%(KSPVersionFile.KspVersion)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;KSP_VERSION_MIN&quot;: &quot;%(KSPVersionFile.KspVersionMin)&quot;," Indent="  "/>
+      <JsonLine Include="&quot;KSP_VERSION_MAX&quot;: &quot;%(KSPVersionFile.KspVersionMax)&quot;" Indent="  "/>
+      <JsonLine Include="}"/>
+    </ItemGroup>
+
+    <!-- Indent lines by their indention property -->
+    <ItemGroup>
+      <JsonFinal Include="@(JsonLine)">
+        <Line>$([System.String]::Concat('%(JsonLine.Indent)', '%(JsonLine.Identity)'))</Line>
+      </JsonFinal>
+    </ItemGroup>
+
+    <!-- Write lines out to file -->
+    <WriteLinesToFile
+            File="%(KSPVersionFile.Destination)"
+            Lines="@(JsonFinal->'%(Line)')"
+            Overwrite="true"
+            Encoding="UTF-8" />
+
+    <Message Text="Writing KSP JSON version file to %(KSPVersionFile.Destination)"/>
     <Message Text="Contents:%0a$(_JSON)" Importance="low"/>
   </Target>
 </Project>


### PR DESCRIPTION
# Motivations
JsonPoke isn't technically required, and while it is beneficial to use something that's specifically meant for JSON file writing, we don't really need it.

# Modifications
- Instead of utilizing JsonPoke, opt-for the built-in `WriteLinesToFile`. This did require a little hacky fix for proper indention, but it's not that hacky in my opinion
- Drop references to JsonPoke