### PR TITLE
Msbuild refactor

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -76,5 +76,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         dotnet msbuild -p:Configuration=${{ inputs.build-configuration }} \
-        -p:ManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
+        -p:KSPManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
         ${{ runner.debug && '-v:detailed' }}

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -76,5 +76,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         dotnet msbuild -p:Configuration=${{ inputs.build-configuration }} \
-        -p:KSPManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
+        -p:KSPBTManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
         ${{ runner.debug && '-v:detailed' }}

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -76,5 +76,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         dotnet msbuild -p:Configuration=${{ inputs.build-configuration }} \
-        -p:KSPBTManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
+        -p:_KSPBT_ManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
         ${{ runner.debug && '-v:detailed' }}

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -77,4 +77,4 @@ runs:
       run: |
         dotnet msbuild -p:Configuration=${{ inputs.build-configuration }} \
         -p:KSPBT_ManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
-        ${{ runner.debug && '-v:detailed' }}
+        ${{ runner.debug && '-v:diagnostic' }}

--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -76,5 +76,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         dotnet msbuild -p:Configuration=${{ inputs.build-configuration }} \
-        -p:_KSPBT_ManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
+        -p:KSPBT_ManagedRelativePath=KSP_x64_Data/Managed ${{ inputs.solution-file-path }} \
         ${{ runner.debug && '-v:detailed' }}

--- a/.github/workflows/internal-test-plugin-nuget.yml
+++ b/.github/workflows/internal-test-plugin-nuget.yml
@@ -13,7 +13,11 @@ env:
   NuGetDirectory: ${{ github.workspace}}/nuget
 
 jobs:
+
   build:
+    strategy:
+      matrix:
+        dotnet-version: [ 5.x, 7.x, 9.x ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -40,10 +44,11 @@ jobs:
           ksp-zip-url: https://github.com/KSPModdingLibs/KSPLibs/raw/main/KSP-1.12.5.zip
           working-directory: ${{ env.TESTDIR }}
           solution-file-path: plugin-mod-nuget.csproj
+          dotnet-version: ${{ matrix.dotnet-version }}
         env:
           KSPBuildToolsVersion: ${{ inputs.package-version }}
 
       - uses: ./.github/actions/assemble-release
         with:
           artifacts: ${{ env.TESTDIR }}/GameData
-          output-file-name: plugin-mod-nuget
+          output-file-name: plugin-mod-nuget-${{ matrix.dotnet-version }}

--- a/.github/workflows/internal-test-plugin-nuget.yml
+++ b/.github/workflows/internal-test-plugin-nuget.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ksp-zip-url: https://github.com/KSPModdingLibs/KSPLibs/raw/main/KSP-1.12.5.zip
           working-directory: ${{ env.TESTDIR }}
-          solution-file-path: plugin-mod.csproj
+          solution-file-path: plugin-mod-nuget.csproj
         env:
           KSPBuildToolsVersion: ${{ inputs.package-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 bin
 obj
 *.nupkg
+packages
 
 # docs
 docs/_build
+
+# misc
+.DS_Store
+.idea
+*.user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ All notable changes to this project will be documented in this file
 
 ### Msbuild
 
-- Renamed global msbuild properties to have the `KSPBT` prefix to avoid namespace collisions with other frameworks
-  - `KSPRoot` is now `KSPBTGameRoot`. It should no longer be referenced within a .csproj file
-  - `RepoRootPath` is now `KSPBTModRoot`, and should now point to the mod folder within GameData rather than the
+- Renamed global msbuild properties to have the `KSPBT_` prefix to avoid namespace collisions with other frameworks
+  - `KSPRoot` is now `KSPBT_GameRoot`. It should no longer be referenced within a .csproj file
+  - `RepoRootPath` is now `KSPBT_ModRoot`, and should now point to the mod folder within GameData rather than the
     root of a git repo
-  - `BinariesOutputRelativePath` is now `KSPBTModPluginFolder`
-  - `GenerateKSPAssemblyAttribute` is now `KSPBTGenerateAssemblyAttribute` and defaults to true
-  - `GenerateKSPAssemblyDependencyAttributes` is now `KSPBTGenerateDependencyAttributes` and defaults to true
-  - `ReferenceUnityAssemblies` is now `KSPBTReferenceUnityAssemblies`
-  - `ReferenceKSPAssemblies` is now `KSPBTReferenceGameAssemblies`
-- Added the `KSPBTReferenceSystemAssemblies` property to control referencing the mono system DLLs within the KSP
+  - `BinariesOutputRelativePath` is now `KSPBT_ModPluginFolder`
+  - `GenerateKSPAssemblyAttribute` is now `KSPBT_GenerateAssemblyAttribute` and defaults to true
+  - `GenerateKSPAssemblyDependencyAttributes` is now `KSPBT_GenerateDependencyAttributes` and defaults to true
+  - `ReferenceUnityAssemblies` is now `KSPBT_ReferenceUnityAssemblies`
+  - `ReferenceKSPAssemblies` is now `KSPBT_ReferenceGameAssemblies`
+- Added the `KSPBT_ReferenceSystemAssemblies` property to control referencing the mono system DLLs within the KSP
   managed folder. Setting this property to false will load the implicit framework DLLs instead.
 - Mod dependencies should now be declared with
   `ModReference` items. This avoids the need for the KSP install path to be known at evaluation time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file
 
+## Unreleased
+
+### Msbuild
+
+- Renamed global msbuild properties to have the `KSPBT` prefix to avoid namespace collisions with other frameworks
+  - `KSPRoot` is now `KSPBTGameRoot`. It should no longer be referenced within a .csproj file
+  - `RepoRootPath` is now `KSPBTModRoot`, and should now point to the mod folder within GameData rather than the
+    root of a git repo
+  - `BinariesOutputRelativePath` is now `KSPBTModPluginFolder`
+  - `GenerateKSPAssemblyAttribute` is now `KSPBTGenerateAssemblyAttribute` and defaults to true
+  - `GenerateKSPAssemblyDependencyAttributes` is now `KSPBTGenerateDependencyAttributes` and defaults to true
+  - `ReferenceUnityAssemblies` is now `KSPBTReferenceUnityAssemblies`
+  - `ReferenceKSPAssemblies` is now `KSPBTReferenceGameAssemblies`
+- Added the `KSPBTReferenceSystemAssemblies` property to control referencing the mono system DLLs within the KSP
+  managed folder. Setting this property to false will load the implicit framework DLLs instead.
+- Mod dependencies should now be declared with
+  `ModReference` items. This avoids the need for the KSP install path to be known at evaluation time.
+
+
 ## 0.0.4 - 2025-06-15
 
 ### Library

--- a/KSPBuildTools.csproj
+++ b/KSPBuildTools.csproj
@@ -24,7 +24,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;NU5128</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>KSPBuildTools</AssemblyName>
-    <KSPBTModRoot>$(ProjectDir)</KSPBTModRoot>
+    <KSPBT_ModRoot>$(ProjectDir)</KSPBT_ModRoot>
     <PackageId>KSPBuildTools</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>KSP Build Tools</Title>

--- a/KSPBuildTools.csproj
+++ b/KSPBuildTools.csproj
@@ -24,7 +24,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;NU5128</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>KSPBuildTools</AssemblyName>
-    <KSPModRoot>$(ProjectDir)</KSPModRoot>
+    <KSPBTModRoot>$(ProjectDir)</KSPBTModRoot>
     <PackageId>KSPBuildTools</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>KSP Build Tools</Title>

--- a/KSPBuildTools.csproj
+++ b/KSPBuildTools.csproj
@@ -50,8 +50,4 @@
     <Compile Remove="$(MSBuildThisFileDirectory)docs/**" />
     <None Remove="$(MSBuildThisFileDirectory)docs/**" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="tests\plugin-mod\plugin-mod.csproj" />
-  </ItemGroup>
 </Project>

--- a/KSPBuildTools.csproj
+++ b/KSPBuildTools.csproj
@@ -24,7 +24,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;NU5128</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>KSPBuildTools</AssemblyName>
-    <RepoRootPath>$(ProjectDir)</RepoRootPath>
+    <KSPModRoot>$(ProjectDir)</KSPModRoot>
     <PackageId>KSPBuildTools</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>KSP Build Tools</Title>
@@ -49,5 +49,9 @@
     <None Remove="$(MSBuildThisFileDirectory).github/**" />
     <Compile Remove="$(MSBuildThisFileDirectory)docs/**" />
     <None Remove="$(MSBuildThisFileDirectory)docs/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="tests\plugin-mod\plugin-mod.csproj" />
   </ItemGroup>
 </Project>

--- a/KSPBuildTools.sln
+++ b/KSPBuildTools.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KSPBuildTools", "KSPBuildTools.csproj", "{F5D90A2D-BF85-4849-9A1B-AD53EE814149}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plugin-mod-legacy", "tests\plugin-mod-legacy\PluginModLegacy\plugin-mod-legacy.csproj", "{F19C7AB4-50C2-4378-9673-CC039CA12E10}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plugin-mod-nuget", "tests\plugin-mod-nuget\plugin-mod-nuget.csproj", "{4F531716-DB82-4AD4-8270-DFB32EE18A41}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "plugin-mod", "tests\plugin-mod\plugin-mod.csproj", "{F0E30935-74A7-446F-A30C-5D1D0E525EC5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F5D90A2D-BF85-4849-9A1B-AD53EE814149}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5D90A2D-BF85-4849-9A1B-AD53EE814149}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5D90A2D-BF85-4849-9A1B-AD53EE814149}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5D90A2D-BF85-4849-9A1B-AD53EE814149}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F19C7AB4-50C2-4378-9673-CC039CA12E10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F19C7AB4-50C2-4378-9673-CC039CA12E10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F19C7AB4-50C2-4378-9673-CC039CA12E10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F19C7AB4-50C2-4378-9673-CC039CA12E10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F531716-DB82-4AD4-8270-DFB32EE18A41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F531716-DB82-4AD4-8270-DFB32EE18A41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F531716-DB82-4AD4-8270-DFB32EE18A41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F531716-DB82-4AD4-8270-DFB32EE18A41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0E30935-74A7-446F-A30C-5D1D0E525EC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0E30935-74A7-446F-A30C-5D1D0E525EC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0E30935-74A7-446F-A30C-5D1D0E525EC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0E30935-74A7-446F-A30C-5D1D0E525EC5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -4,7 +4,27 @@
     <KSPCommonPropsImported>true</KSPCommonPropsImported>
   </PropertyGroup>
 
-  <!-- default settings for KSPBT_ targets and references -->
+  <!-- default settings for when building for Unity-->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Unity' ">
+    <!-- Dont KSP and mod assemblies -->
+    <KSPBT_ReferenceGameAssemblies Condition=" '$(KSPBT_ReferenceGameAssemblies)' == '' ">false</KSPBT_ReferenceGameAssemblies>
+    <KSPBT_ReferenceModAssemblies Condition=" '$(KSPBT_ReferenceModAssemblies)' == '' ">false</KSPBT_ReferenceModAssemblies>
+
+    <!-- Dont install mod dependencies from CKAN (they wont be referenced anyways) -->
+    <KSPBT_InstallCKANDependencies Condition=" '$(KSPBT_InstallCKANDependencies)' == '' ">false</KSPBT_InstallCKANDependencies>
+
+    <!-- Dont generate attributes since they depend on the KSP Assembly_Csharp.dll -->
+    <KSPBT_GenerateAssemblyAttribute Condition=" '$(KSPBT_GenerateAssemblyAttribute)' == '' ">false</KSPBT_GenerateAssemblyAttribute>
+    <KSPBT_GenerateDependencyAttributes Condition=" '$(KSPBT_GenerateDependencyAttributes)' == '' ">false</KSPBT_GenerateDependencyAttributes>
+
+    <!-- Dont copy DLLs to mod folder, since theyre not the full mod-->
+    <KSPBT_CopyDLLsToPluginFolder Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == '' ">false</KSPBT_CopyDLLsToPluginFolder>
+
+    <!-- Dont generate a version file -->
+    <KSPBT_GenerateVersionFile Condition=" '$(KSPBT_GenerateVersionFile)' == '' ">false</KSPBT_GenerateVersionFile>
+  </PropertyGroup>
+
+  <!-- default settings when building normally -->
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
     <KSPBT_ModRoot Condition=" '$(KSPBT_ModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPBT_ModRoot>
@@ -15,30 +35,35 @@
     <!-- default CKAN compatibility versions -->
     <KSPBT_CKANCompatibleVersions Condition=" '$(KSPBT_CKANCompatibleVersions)' == '' ">1.12 1.11 1.10 1.9 1.8</KSPBT_CKANCompatibleVersions>
 
-    <!-- reference unity and KSP assemblies unless explicitly disabled -->
+    <!-- reference system, unity, KSP, and dependency mod assemblies -->
     <KSPBT_ReferenceSystemAssemblies Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == '' ">true</KSPBT_ReferenceSystemAssemblies>
     <KSPBT_ReferenceUnityAssemblies Condition=" '$(KSPBT_ReferenceUnityAssemblies)' == '' ">true</KSPBT_ReferenceUnityAssemblies>
     <KSPBT_ReferenceGameAssemblies Condition=" '$(KSPBT_ReferenceGameAssemblies)' == '' ">true</KSPBT_ReferenceGameAssemblies>
     <KSPBT_ReferenceModAssemblies Condition=" '$(KSPBT_ReferenceModAssemblies)' == '' ">true</KSPBT_ReferenceModAssemblies>
 
-    <!-- Copy DLLs to mod folder -->
+    <!-- Install all dependency mods from CKAN -->
     <KSPBT_InstallCKANDependencies Condition=" '$(KSPBT_InstallCKANDependencies)' == '' ">true</KSPBT_InstallCKANDependencies>
 
-    <KSPBT_CopyDLLsToPluginFolder Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == '' ">true</KSPBT_CopyDLLsToPluginFolder>
-
+    <!-- Generate KSP assembly and dependency attributes for the assembly -->
     <KSPBT_GenerateAssemblyAttribute Condition=" '$(KSPBT_GenerateAssemblyAttribute)' == '' ">true</KSPBT_GenerateAssemblyAttribute>
-
     <KSPBT_GenerateDependencyAttributes Condition=" '$(KSPBT_GenerateDependencyAttributes)' == '' ">true</KSPBT_GenerateDependencyAttributes>
 
+    <!-- Copy DLLs to mod folder -->
+    <KSPBT_CopyDLLsToPluginFolder Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == '' ">true</KSPBT_CopyDLLsToPluginFolder>
 
     <KSPBT_GenerateVersionFile Condition=" '$(KSPBT_GenerateVersionFile)' == '' ">true</KSPBT_GenerateVersionFile>
   </PropertyGroup>
 
-  <!-- Define the ModReference item type and its defaults -->
+  <!-- Define items -->
   <ItemDefinitionGroup>
     <ModReference>
       <Private>false</Private>
     </ModReference>
+    <KSPVersionFile>
+      <KSP_Version>1.12</KSP_Version>
+      <KSP_Version_Min>1.8</KSP_Version_Min>
+      <KSP_Version_Max>1.12</KSP_Version_Max>
+    </KSPVersionFile>
   </ItemDefinitionGroup>
 
   <!--Parse KSP platform-specific paths -->

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -112,19 +112,6 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup>
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -56,61 +56,12 @@
     <_KSPBT_SteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</_KSPBT_SteamGameRoot>
   </PropertyGroup>
 
-  <!-- Import the csproj.user file. -->
-  <!-- This can overwrite KSPBT_ManagedRelativePath and _KSPBT_GameExecutable,
-       set KSPBT_GameRoot and ReferencePath, and any other user-specific settings -->
-  <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
-
   <!-- Import a props.user file -->
   <!-- serves the same role as the csproj.user file -->
   <Import Condition=" Exists('$(SolutionDir)$(SolutionName).props.user') " Project="$(SolutionDir)$(SolutionName).props.user"/>
 
   <!-- Import solution-wide props if it exists -->
   <Import Condition=" Exists('$(SolutionDir)$(SolutionName).props') " Project="$(SolutionDir)$(SolutionName).props"/>
-
-  <!-- Relative path that must exist for a path to be a valid KSP Install-->
-  <PropertyGroup>
-    <KSPBT_GameIdentifier>$(KSPBT_ManagedRelativePath)/Assembly-CSharp.dll</KSPBT_GameIdentifier>
-    <KSPBT_GameRootSource Condition="'$(KSPBT_GameRoot)' != ''">property</KSPBT_GameRootSource>
-  </PropertyGroup>
-
-  <!-- Default KSPBT_GameRoot to the "KSP_ROOT" environment variable if it exists -->
-  <!-- Doing this skips any checks for a valid KSP install so be careful! -->
-  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And '$(KSP_ROOT)' != '' ">
-    <KSPBT_GameRoot>$(KSP_ROOT)</KSPBT_GameRoot>
-    <KSPBT_GameRootSource>environment variable</KSPBT_GameRootSource>
-  </PropertyGroup>
-  <ItemGroup>
-    <KSPBT_GameRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
-    <KSPBT_GameRootCandidate Include="$(ReferencePath)" source="reference path"/>
-    <KSPBT_GameRootCandidate Include="$(_KSPBT_SteamGameRoot)" source="steam"/>
-  </ItemGroup>
-
-  <!-- Look for KSP install in Solution dir -->
-  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPBT_GameIdentifier)') ">
-    <KSPBT_GameRoot>$(SolutionDir)KSP</KSPBT_GameRoot>
-    <KSPBT_GameRootSource>solution directory</KSPBT_GameRootSource>
-  </PropertyGroup>
-
-  <!-- Look for KSP install in ReferencePath -->
-  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(ReferencePath)/$(KSPBT_GameIdentifier)') ">
-    <KSPBT_GameRoot>$(ReferencePath)</KSPBT_GameRoot>
-    <KSPBT_GameRootSource>reference path</KSPBT_GameRootSource>
-  </PropertyGroup>
-
-  <!-- Look for KSP steam install-->
-  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(_KSPBT_SteamGameRoot)/$(KSPBT_GameIdentifier)') ">
-    <KSPBT_GameRoot>$(_KSPBT_SteamGameRoot)</KSPBT_GameRoot>
-    <KSPBT_GameRootSource>steam</KSPBT_GameRootSource>
-  </PropertyGroup>
-
-  <!-- set the start action so that you can launch directly from VS -->
-  <PropertyGroup>
-    <StartAction>Program</StartAction>
-    <StartProgram>$(KSPBT_GameRoot)/$(_KSPBT_GameExecutable)</StartProgram>
-    <StartWorkingDirectory>$(KSPBT_GameRoot)</StartWorkingDirectory>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -7,77 +7,47 @@
   <!-- default settings for KSPBT targets and references -->
   <PropertyGroup>
     <!-- reference unity and KSP assemblies unless explicitly disabled -->
-    <ReferenceKSPSystemAssemblies Condition=" '$(ReferenceKSPSystemAssemblies)' == '' ">
-      true
-    </ReferenceKSPSystemAssemblies>
-    <ReferenceKSPUnityAssemblies Condition=" '$(ReferenceKSPUnityAssemblies)' == '' ">
-      true
-    </ReferenceKSPUnityAssemblies>
-    <ReferenceKSPGameAssemblies Condition=" '$(ReferenceKSPGameAssemblies)' == '' ">
-      true
-    </ReferenceKSPGameAssemblies>
+    <ReferenceKSPSystemAssemblies Condition=" '$(ReferenceKSPSystemAssemblies)' == '' ">true</ReferenceKSPSystemAssemblies>
+    <ReferenceKSPUnityAssemblies Condition=" '$(ReferenceKSPUnityAssemblies)' == '' ">true</ReferenceKSPUnityAssemblies>
+    <ReferenceKSPGameAssemblies Condition=" '$(ReferenceKSPGameAssemblies)' == '' ">true</ReferenceKSPGameAssemblies>
 
 
     <!-- Copy DLLs to mod folder -->
-    <CopyDLLsToPluginFolder Condition=" '$(CopyDLLsToPluginFolder)' == '' ">
-      true
-    </CopyDLLsToPluginFolder>
+    <CopyDLLsToPluginFolder Condition=" '$(CopyDLLsToPluginFolder)' == '' ">true</CopyDLLsToPluginFolder>
 
 
-    <GenerateKSPAssemblyAttribute Condition=" '$(GenerateKSPAssemblyAttribute)' == '' ">
-      true
-    </GenerateKSPAssemblyAttribute>
+    <GenerateKSPAssemblyAttribute Condition=" '$(GenerateKSPAssemblyAttribute)' == '' ">true</GenerateKSPAssemblyAttribute>
 
-    <GenerateKSPAssemblyDependencyAttributes Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == '' ">
-      true
-    </GenerateKSPAssemblyDependencyAttributes>
+    <GenerateKSPAssemblyDependencyAttributes Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == '' ">true</GenerateKSPAssemblyDependencyAttributes>
 
-    <GenerateKSPVersionFile Condition=" '$(GenerateKSPVersionFile)' == '' ">
-      true
-    </GenerateKSPVersionFile>
+    <GenerateKSPVersionFile Condition=" '$(GenerateKSPVersionFile)' == '' ">true</GenerateKSPVersionFile>
 
     <!-- default CKAN compatibility versions -->
-    <CKANCompatibleVersions Condition=" '$(CKANCompatibleVersions)' == '' ">
-      1.12 1.11 1.10 1.9 1.8
-    </CKANCompatibleVersions>
+    <CKANCompatibleVersions Condition=" '$(CKANCompatibleVersions)' == '' ">1.12 1.11 1.10 1.9 1.8</CKANCompatibleVersions>
   </PropertyGroup>
 
   <!--Parse KSP platform-specific paths -->
   <!-- These can be overwritten by user and props files -->
   <PropertyGroup Condition=" '$(KSPManagedRelativePath)' == '' ">
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
-      KSP_x64_Data/Managed
-    </KSPManagedRelativePath>
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
-      KSP.app/Contents/Resources/Data/Managed
-    </KSPManagedRelativePath>
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">
-      KSP_Data/Managed
-    </KSPManagedRelativePath>
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</KSPManagedRelativePath>
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</KSPManagedRelativePath>
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</KSPManagedRelativePath>
   </PropertyGroup>
 
   <PropertyGroup>
     <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</KSPExecutable>
     <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</KSPExecutable>
     <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</KSPExecutable>
-    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
-      C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program
-    </SteamKSPRoot>
-    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
-      $(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program
-    </SteamKSPRoot>
+    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</SteamKSPRoot>
+    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</SteamKSPRoot>
   </PropertyGroup>
 
   <!-- Calculate mod paths -->
   <!-- These can be overwritten by user, csproj, and props files -->
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
-    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">
-      $(ProjectDir)/../GameData/$(ProjectName)/
-    </KSPModRoot>
-    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' ">
-      $(KSPModGameData)/Plugins/
-    </KSPModPluginFolder>
+    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">$(ProjectDir)/../GameData/$(ProjectName)/</KSPModRoot>
+    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' ">$(KSPModGameData)/Plugins/</KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->
@@ -140,6 +110,57 @@
     <StartWorkingDirectory>$(KSPRoot)</StartWorkingDirectory>
     <DebugType>portable</DebugType>
   </PropertyGroup>
+
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <FrameworkPathOverride>$(ManagedPath)</FrameworkPathOverride>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+
+  <!-- Import references -->
+  <ItemGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/System.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/System.Core.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/mscorlib.dll">
+      <Name>System.Core (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/System.Xml.dll">
+      <Name>System.Xml (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceKSPUnityAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/UnityEngine*.dll">
+      <Name>UnityEngine</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceKSPGameAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/Assembly-CSharp.dll">
+      <Name>Assembly-CSharp</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/Assembly-CSharp-firstpass.dll">
+      <Name>Assembly-CSharp-firstpass</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -114,14 +114,7 @@
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
   <PropertyGroup>
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -111,6 +111,19 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup>
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -112,11 +112,6 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup>
-
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -104,6 +104,11 @@
     <KSPBT_GameRootSource>steam</KSPBT_GameRootSource>
   </PropertyGroup>
 
+  <!-- Calculate KSPBT_ManagedPath -->
+  <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
+    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
+  </PropertyGroup>
+
   <!-- set the start action so that you can launch directly from VS -->
   <PropertyGroup>
     <StartAction>Program</StartAction>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -58,6 +58,7 @@
   <ItemDefinitionGroup>
     <ModReference>
       <Private>false</Private>
+      <GenerateDependencyAttribute>true</GenerateDependencyAttribute>
     </ModReference>
     <KSPVersionFile>
       <KSP_Version>1.12</KSP_Version>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -42,10 +42,10 @@
   </ItemDefinitionGroup>
 
   <!--Parse KSP platform-specific paths -->
-  <PropertyGroup Condition=" '$(_KSPBT_ManagedRelativePath)' == '' ">
-    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</_KSPBT_ManagedRelativePath>
-    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</_KSPBT_ManagedRelativePath>
-    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</_KSPBT_ManagedRelativePath>
+  <PropertyGroup Condition=" '$(KSPBT_ManagedRelativePath)' == '' ">
+    <KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</KSPBT_ManagedRelativePath>
+    <KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</KSPBT_ManagedRelativePath>
+    <KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</KSPBT_ManagedRelativePath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -57,7 +57,7 @@
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->
-  <!-- This can overwrite _KSPBT_ManagedRelativePath and _KSPBT_GameExecutable,
+  <!-- This can overwrite KSPBT_ManagedRelativePath and _KSPBT_GameExecutable,
        set KSPBT_GameRoot and ReferencePath, and any other user-specific settings -->
   <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
 
@@ -70,7 +70,7 @@
 
   <!-- Relative path that must exist for a path to be a valid KSP Install-->
   <PropertyGroup>
-    <KSPBT_GameIdentifier>$(_KSPBT_ManagedRelativePath)/Assembly-CSharp.dll</KSPBT_GameIdentifier>
+    <KSPBT_GameIdentifier>$(KSPBT_ManagedRelativePath)/Assembly-CSharp.dll</KSPBT_GameIdentifier>
     <KSPBT_GameRootSource Condition="'$(KSPBT_GameRoot)' != ''">property</KSPBT_GameRootSource>
   </PropertyGroup>
 
@@ -102,11 +102,6 @@
   <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(_KSPBT_SteamGameRoot)/$(KSPBT_GameIdentifier)') ">
     <KSPBT_GameRoot>$(_KSPBT_SteamGameRoot)</KSPBT_GameRoot>
     <KSPBT_GameRootSource>steam</KSPBT_GameRootSource>
-  </PropertyGroup>
-
-  <!-- Calculate KSPBT_ManagedPath -->
-  <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
-    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
   <!-- set the start action so that you can launch directly from VS -->

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -46,7 +46,7 @@
   <!-- These can be overwritten by user, csproj, and props files -->
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
-    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">$(ProjectDir)/../GameData/$(ProjectName)/</KSPModRoot>
+    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPModRoot>
     <!-- The folder to place resulting DLLs into, relative to KSPModRoot -->
     <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' "/>
   </PropertyGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -4,47 +4,84 @@
     <KSPCommonPropsImported>true</KSPCommonPropsImported>
   </PropertyGroup>
 
-  <!-- disable default .net framework imports; use the ones from KSP instead.  There are a few differences that are sometimes important. -->
+  <!-- default settings for KSPBT targets and references -->
   <PropertyGroup>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
+    <!-- reference unity and KSP assemblies unless explicitly disabled -->
+    <ReferenceKSPSystemAssemblies Condition=" '$(ReferenceKSPSystemAssemblies)' == '' ">
+      true
+    </ReferenceKSPSystemAssemblies>
+    <ReferenceKSPUnityAssemblies Condition=" '$(ReferenceKSPUnityAssemblies)' == '' ">
+      true
+    </ReferenceKSPUnityAssemblies>
+    <ReferenceKSPGameAssemblies Condition=" '$(ReferenceKSPGameAssemblies)' == '' ">
+      true
+    </ReferenceKSPGameAssemblies>
 
-  <!--reference unity and KSP assemblies unless explicitly disabled-->
-  <PropertyGroup>
-    <ReferenceUnityAssemblies Condition=" '$(ReferenceUnityAssemblies)' == '' ">true</ReferenceUnityAssemblies>
-    <ReferenceKSPAssemblies Condition=" '$(ReferenceKSPAssemblies)' == '' ">true</ReferenceKSPAssemblies>
-  </PropertyGroup>
 
-  <!-- default CKAN compatibility versions -->
-  <PropertyGroup>
-    <CKANCompatibleVersions Condition="('$(CKANCompatibleVersions)' == '')">1.12 1.11 1.10 1.9 1.8</CKANCompatibleVersions>
+    <!-- Copy DLLs to mod folder -->
+    <CopyDLLsToPluginFolder Condition=" '$(CopyDLLsToPluginFolder)' == '' ">
+      true
+    </CopyDLLsToPluginFolder>
+
+
+    <GenerateKSPAssemblyAttribute Condition=" '$(GenerateKSPAssemblyAttribute)' == '' ">
+      true
+    </GenerateKSPAssemblyAttribute>
+
+    <GenerateKSPAssemblyDependencyAttributes Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == '' ">
+      true
+    </GenerateKSPAssemblyDependencyAttributes>
+
+    <GenerateKSPVersionFile Condition=" '$(GenerateKSPVersionFile)' == '' ">
+      true
+    </GenerateKSPVersionFile>
+
+    <!-- default CKAN compatibility versions -->
+    <CKANCompatibleVersions Condition=" '$(CKANCompatibleVersions)' == '' ">
+      1.12 1.11 1.10 1.9 1.8
+    </CKANCompatibleVersions>
   </PropertyGroup>
 
   <!--Parse KSP platform-specific paths -->
   <!-- These can be overwritten by user and props files -->
-  <PropertyGroup Condition=" '$(ManagedRelativePath)' == '' ">
-    <ManagedRelativePath Condition="$([MSBuild]::IsOsPlatform('Windows'))">KSP_x64_Data\Managed</ManagedRelativePath>
-    <ManagedRelativePath Condition="$([MSBuild]::IsOsPlatform('OSX'))">KSP.app\Contents\Resources\Data\Managed</ManagedRelativePath>
-    <ManagedRelativePath Condition="$([MSBuild]::IsOsPlatform('Linux'))">KSP_Data\Managed</ManagedRelativePath>
+  <PropertyGroup Condition=" '$(KSPManagedRelativePath)' == '' ">
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+      KSP_x64_Data/Managed
+    </KSPManagedRelativePath>
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
+      KSP.app/Contents/Resources/Data/Managed
+    </KSPManagedRelativePath>
+    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">
+      KSP_Data/Managed
+    </KSPManagedRelativePath>
   </PropertyGroup>
+
   <PropertyGroup>
-    <KSPExecutable Condition="$([MSBuild]::IsOsPlatform('Windows'))">KSP_x64.exe</KSPExecutable>
-    <KSPExecutable Condition="$([MSBuild]::IsOsPlatform('OSX'))">KSP.app/Contents/MacOS/KSP</KSPExecutable>
-    <KSPExecutable Condition="$([MSBuild]::IsOsPlatform('Linux'))">KSP.x86_64</KSPExecutable>
-    <SteamKSPRoot Condition="($([MSBuild]::IsOsPlatform('Windows')))">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</SteamKSPRoot>
-    <SteamKSPRoot Condition="($([MSBuild]::IsOsPlatform('OSX')))">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</SteamKSPRoot>
+    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</KSPExecutable>
+    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</KSPExecutable>
+    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</KSPExecutable>
+    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+      C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program
+    </SteamKSPRoot>
+    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">
+      $(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program
+    </SteamKSPRoot>
   </PropertyGroup>
 
   <!-- Calculate mod paths -->
   <!-- These can be overwritten by user, csproj, and props files -->
   <PropertyGroup>
-    <!-- The root directory of the mod repository -->
-    <RepoRootPath Condition=" '$(RepoRootPath)' == '' ">$(SolutionDir.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</RepoRootPath>
-    <BinariesOutputRelativePath Condition=" '$(BinariesOutputRelativePath)' == '' ">GameData/$(SolutionName)</BinariesOutputRelativePath>
+    <!-- The root directory of the mod, the folder that gets placed in GameData -->
+    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">
+      $(ProjectDir)/../GameData/$(ProjectName)/
+    </KSPModRoot>
+    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' ">
+      $(KSPModGameData)/Plugins/
+    </KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->
-  <!-- This can overwrite ManagedRelativePath and KSPExecutable,
+  <!-- This can overwrite KSPManagedRelativePath and KSPExecutable,
        set KSPRoot and ReferencePath, and any other user-specific settings -->
   <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
 
@@ -55,16 +92,16 @@
   <!-- Import solution-wide props if it exists -->
   <Import Condition=" Exists('$(SolutionDir)$(SolutionName).props') " Project="$(SolutionDir)$(SolutionName).props"/>
 
+  <!-- Relative path that must exist for a path to be a valid KSP Install-->
   <PropertyGroup>
-    <!-- Relative path that must exist for a path to be a valid KSP Install-->
-    <KSPRootIdentifier>$(ManagedRelativePath)/Assembly-CSharp.dll</KSPRootIdentifier>
+    <KSPRootIdentifier>$(KSPManagedRelativePath)/Assembly-CSharp.dll</KSPRootIdentifier>
     <KSPRootSource Condition="'$(KSPRoot)' != ''">property</KSPRootSource>
   </PropertyGroup>
 
+  <!-- Default KSPRoot to the "KSP_ROOT" environment variable if it exists -->
+  <!-- Doing this skips any checks for a valid KSP install so be careful! -->
   <PropertyGroup Condition=" '$(KSPRoot)' == '' And '$(KSP_ROOT)' != '' ">
-    <!-- Default KSPRoot to the "KSP_ROOT" environment variable if it exists -->
-    <!-- Doing this skips any checks for a valid KSP install so be careful! -->
-    <KSPRoot >$(KSP_ROOT)</KSPRoot>
+    <KSPRoot>$(KSP_ROOT)</KSPRoot>
     <KSPRootSource>environment variable</KSPRootSource>
   </PropertyGroup>
   <ItemGroup>
@@ -73,86 +110,38 @@
     <KSPRootCandidate Include="$(SteamKSPRoot)" source="steam"/>
   </ItemGroup>
 
+  <!-- Look for KSP install in Solution dir -->
   <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPRootIdentifier)') ">
-    <!-- Look for KSP install in Solution dir -->
-    <KSPRoot >$(SolutionDir)KSP</KSPRoot>
+    <KSPRoot>$(SolutionDir)KSP</KSPRoot>
     <KSPRootSource>solution directory</KSPRootSource>
   </PropertyGroup>
 
+  <!-- Look for KSP install in ReferencePath -->
   <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(ReferencePath)/$(KSPRootIdentifier)') ">
-    <!-- Look for KSP install in ReferencePath -->
     <KSPRoot>$(ReferencePath)</KSPRoot>
     <KSPRootSource>reference path</KSPRootSource>
   </PropertyGroup>
 
+  <!-- Look for KSP steam install-->
   <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(SteamKSPRoot)/$(KSPRootIdentifier)') ">
-    <!-- Look for KSP steam install-->
     <KSPRoot>$(SteamKSPRoot)</KSPRoot>
     <KSPRootSource>steam</KSPRootSource>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Calculate ManagedPath -->
-    <ManagedPath>$(KSPRoot)/$(ManagedRelativePath)</ManagedPath>
+  <!-- Calculate ManagedPath -->
+  <PropertyGroup Condition=" '$(ManagedPath)' == ''">
+    <ManagedPath>$(KSPRoot)/$(KSPManagedRelativePath)</ManagedPath>
   </PropertyGroup>
 
   <!-- set the start action so that you can launch directly from VS -->
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>$(KSPRoot)\$(KSPExecutable)</StartProgram>
+    <StartProgram>$(KSPRoot)/$(KSPExecutable)</StartProgram>
     <StartWorkingDirectory>$(KSPRoot)</StartWorkingDirectory>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup>
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(ManagedPath)</FrameworkPathOverride>
-  </PropertyGroup>
-
-  <!--Import references-->
   <ItemGroup>
-    <Reference Include="$(ManagedPath)\System.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)\System.Core.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)\mscorlib.dll">
-      <Name>System.Core (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)\System.Xml.dll">
-      <Name>System.Xml (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceUnityAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)\UnityEngine*.dll">
-      <Name>UnityEngine</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceKSPAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)\Assembly-CSharp.dll">
-      <Name>Assembly-CSharp</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)\Assembly-CSharp-firstpass.dll">
-      <Name>Assembly-CSharp-firstpass</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include = "$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
+    <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>
 </Project>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -4,55 +4,61 @@
     <KSPCommonPropsImported>true</KSPCommonPropsImported>
   </PropertyGroup>
 
-  <!-- default settings for KSPBT targets and references -->
-  <PropertyGroup>
-    <!-- reference unity and KSP assemblies unless explicitly disabled -->
-    <KSPBTReferenceSystemAssemblies Condition=" '$(KSPBTReferenceSystemAssemblies)' == '' ">true</KSPBTReferenceSystemAssemblies>
-    <KSPBTReferenceUnityAssemblies Condition=" '$(KSPBTReferenceUnityAssemblies)' == '' ">true</KSPBTReferenceUnityAssemblies>
-    <KSPBTReferenceGameAssemblies Condition=" '$(KSPBTReferenceGameAssemblies)' == '' ">true</KSPBTReferenceGameAssemblies>
-
-    <!-- Copy DLLs to mod folder -->
-    <KSPBTCopyDLLsToPluginFolder Condition=" '$(KSPBTCopyDLLsToPluginFolder)' == '' ">true</KSPBTCopyDLLsToPluginFolder>
-
-
-    <KSPBTGenerateAssemblyAttribute Condition=" '$(KSPBTGenerateAssemblyAttribute)' == '' ">true</KSPBTGenerateAssemblyAttribute>
-
-    <KSPBTGenerateDependencyAttributes Condition=" '$(KSPBTGenerateDependencyAttributes)' == '' ">true</KSPBTGenerateDependencyAttributes>
-
-    <KSPBTGenerateVersionFile Condition=" '$(KSPBTGenerateVersionFile)' == '' ">true</KSPBTGenerateVersionFile>
-
-    <!-- default CKAN compatibility versions -->
-    <CKANCompatibleVersions Condition=" '$(CKANCompatibleVersions)' == '' ">1.12 1.11 1.10 1.9 1.8</CKANCompatibleVersions>
-  </PropertyGroup>
-
-  <!--Parse KSP platform-specific paths -->
-  <!-- These can be overwritten by user and props files -->
-  <PropertyGroup Condition=" '$(KSPBTManagedRelativePath)' == '' ">
-    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</KSPBTManagedRelativePath>
-    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</KSPBTManagedRelativePath>
-    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</KSPBTManagedRelativePath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</KSPBTGameExecutable>
-    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</KSPBTGameExecutable>
-    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</KSPBTGameExecutable>
-    <KSPBTSteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</KSPBTSteamGameRoot>
-    <KSPBTSteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</KSPBTSteamGameRoot>
-  </PropertyGroup>
-
-  <!-- Calculate mod paths -->
-  <!-- These can be overwritten by user, csproj, and props files -->
+  <!-- default settings for KSPBT_ targets and references -->
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
-    <KSPBTModRoot Condition=" '$(KSPBTModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPBTModRoot>
-    <!-- The folder to place resulting DLLs into, relative to KSPBTModRoot -->
-    <KSPBTModPluginFolder Condition=" '$(KSPBTModPluginFolder)' == '' "/>
+    <KSPBT_ModRoot Condition=" '$(KSPBT_ModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPBT_ModRoot>
+
+    <!-- The folder to place resulting DLLs into, relative to KSPBT_ModRoot -->
+    <KSPBT_ModPluginFolder Condition=" '$(KSPBT_ModPluginFolder)' == '' "/>
+
+    <!-- default CKAN compatibility versions -->
+    <KSPBT_CKANCompatibleVersions Condition=" '$(KSPBT_CKANCompatibleVersions)' == '' ">1.12 1.11 1.10 1.9 1.8</KSPBT_CKANCompatibleVersions>
+
+    <!-- reference unity and KSP assemblies unless explicitly disabled -->
+    <KSPBT_ReferenceSystemAssemblies Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == '' ">true</KSPBT_ReferenceSystemAssemblies>
+    <KSPBT_ReferenceUnityAssemblies Condition=" '$(KSPBT_ReferenceUnityAssemblies)' == '' ">true</KSPBT_ReferenceUnityAssemblies>
+    <KSPBT_ReferenceGameAssemblies Condition=" '$(KSPBT_ReferenceGameAssemblies)' == '' ">true</KSPBT_ReferenceGameAssemblies>
+    <KSPBT_ReferenceModAssemblies Condition=" '$(KSPBT_ReferenceModAssemblies)' == '' ">true</KSPBT_ReferenceModAssemblies>
+
+    <!-- Copy DLLs to mod folder -->
+    <KSPBT_InstallCKANDependencies Condition=" '$(KSPBT_InstallCKANDependencies)' == '' ">true</KSPBT_InstallCKANDependencies>
+
+    <KSPBT_CopyDLLsToPluginFolder Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == '' ">true</KSPBT_CopyDLLsToPluginFolder>
+
+    <KSPBT_GenerateAssemblyAttribute Condition=" '$(KSPBT_GenerateAssemblyAttribute)' == '' ">true</KSPBT_GenerateAssemblyAttribute>
+
+    <KSPBT_GenerateDependencyAttributes Condition=" '$(KSPBT_GenerateDependencyAttributes)' == '' ">true</KSPBT_GenerateDependencyAttributes>
+
+
+    <KSPBT_GenerateVersionFile Condition=" '$(KSPBT_GenerateVersionFile)' == '' ">true</KSPBT_GenerateVersionFile>
+  </PropertyGroup>
+
+  <!-- Define the ModReference item type and its defaults -->
+  <ItemDefinitionGroup>
+    <ModReference>
+      <Private>false</Private>
+    </ModReference>
+  </ItemDefinitionGroup>
+
+  <!--Parse KSP platform-specific paths -->
+  <PropertyGroup Condition=" '$(_KSPBT_ManagedRelativePath)' == '' ">
+    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</_KSPBT_ManagedRelativePath>
+    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</_KSPBT_ManagedRelativePath>
+    <_KSPBT_ManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</_KSPBT_ManagedRelativePath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_KSPBT_GameExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</_KSPBT_GameExecutable>
+    <_KSPBT_GameExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</_KSPBT_GameExecutable>
+    <_KSPBT_GameExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</_KSPBT_GameExecutable>
+    <_KSPBT_SteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</_KSPBT_SteamGameRoot>
+    <_KSPBT_SteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</_KSPBT_SteamGameRoot>
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->
-  <!-- This can overwrite KSPBTManagedRelativePath and KSPBTGameExecutable,
-       set KSPBTGameRoot and ReferencePath, and any other user-specific settings -->
+  <!-- This can overwrite _KSPBT_ManagedRelativePath and _KSPBT_GameExecutable,
+       set KSPBT_GameRoot and ReferencePath, and any other user-specific settings -->
   <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
 
   <!-- Import a props.user file -->
@@ -64,50 +70,45 @@
 
   <!-- Relative path that must exist for a path to be a valid KSP Install-->
   <PropertyGroup>
-    <KSPBTGameIdentifier>$(KSPBTManagedRelativePath)/Assembly-CSharp.dll</KSPBTGameIdentifier>
-    <KSPBTGameRootSource Condition="'$(KSPBTGameRoot)' != ''">property</KSPBTGameRootSource>
+    <KSPBT_GameIdentifier>$(_KSPBT_ManagedRelativePath)/Assembly-CSharp.dll</KSPBT_GameIdentifier>
+    <KSPBT_GameRootSource Condition="'$(KSPBT_GameRoot)' != ''">property</KSPBT_GameRootSource>
   </PropertyGroup>
 
-  <!-- Default KSPBTGameRoot to the "KSP_ROOT" environment variable if it exists -->
+  <!-- Default KSPBT_GameRoot to the "KSP_ROOT" environment variable if it exists -->
   <!-- Doing this skips any checks for a valid KSP install so be careful! -->
-  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And '$(KSP_ROOT)' != '' ">
-    <KSPBTGameRoot>$(KSP_ROOT)</KSPBTGameRoot>
-    <KSPBTGameRootSource>environment variable</KSPBTGameRootSource>
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And '$(KSP_ROOT)' != '' ">
+    <KSPBT_GameRoot>$(KSP_ROOT)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>environment variable</KSPBT_GameRootSource>
   </PropertyGroup>
   <ItemGroup>
-    <KSPBTGameRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
-    <KSPBTGameRootCandidate Include="$(ReferencePath)" source="reference path"/>
-    <KSPBTGameRootCandidate Include="$(KSPBTSteamGameRoot)" source="steam"/>
+    <KSPBT_GameRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
+    <KSPBT_GameRootCandidate Include="$(ReferencePath)" source="reference path"/>
+    <KSPBT_GameRootCandidate Include="$(_KSPBT_SteamGameRoot)" source="steam"/>
   </ItemGroup>
 
   <!-- Look for KSP install in Solution dir -->
-  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPBTGameIdentifier)') ">
-    <KSPBTGameRoot>$(SolutionDir)KSP</KSPBTGameRoot>
-    <KSPBTGameRootSource>solution directory</KSPBTGameRootSource>
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(SolutionDir)KSP</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>solution directory</KSPBT_GameRootSource>
   </PropertyGroup>
 
   <!-- Look for KSP install in ReferencePath -->
-  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(ReferencePath)/$(KSPBTGameIdentifier)') ">
-    <KSPBTGameRoot>$(ReferencePath)</KSPBTGameRoot>
-    <KSPBTGameRootSource>reference path</KSPBTGameRootSource>
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(ReferencePath)/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(ReferencePath)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>reference path</KSPBT_GameRootSource>
   </PropertyGroup>
 
   <!-- Look for KSP steam install-->
-  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(KSPBTSteamGameRoot)/$(KSPBTGameIdentifier)') ">
-    <KSPBTGameRoot>$(KSPBTSteamGameRoot)</KSPBTGameRoot>
-    <KSPBTGameRootSource>steam</KSPBTGameRootSource>
-  </PropertyGroup>
-
-  <!-- Calculate KSPBTManagedPath -->
-  <PropertyGroup Condition=" '$(KSPBTManagedPath)' == ''">
-    <KSPBTManagedPath>$(KSPBTGameRoot)/$(KSPBTManagedRelativePath)</KSPBTManagedPath>
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(_KSPBT_SteamGameRoot)/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(_KSPBT_SteamGameRoot)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>steam</KSPBT_GameRootSource>
   </PropertyGroup>
 
   <!-- set the start action so that you can launch directly from VS -->
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>$(KSPBTGameRoot)/$(KSPBTGameExecutable)</StartProgram>
-    <StartWorkingDirectory>$(KSPBTGameRoot)</StartWorkingDirectory>
+    <StartProgram>$(KSPBT_GameRoot)/$(_KSPBT_GameExecutable)</StartProgram>
+    <StartWorkingDirectory>$(KSPBT_GameRoot)</StartWorkingDirectory>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
@@ -120,7 +121,7 @@
     <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
          from attempting to locate an external copy of the reference assemblies. -->
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
+    <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -7,20 +7,19 @@
   <!-- default settings for KSPBT targets and references -->
   <PropertyGroup>
     <!-- reference unity and KSP assemblies unless explicitly disabled -->
-    <ReferenceKSPSystemAssemblies Condition=" '$(ReferenceKSPSystemAssemblies)' == '' ">true</ReferenceKSPSystemAssemblies>
-    <ReferenceKSPUnityAssemblies Condition=" '$(ReferenceKSPUnityAssemblies)' == '' ">true</ReferenceKSPUnityAssemblies>
-    <ReferenceKSPGameAssemblies Condition=" '$(ReferenceKSPGameAssemblies)' == '' ">true</ReferenceKSPGameAssemblies>
-
+    <KSPBTReferenceSystemAssemblies Condition=" '$(KSPBTReferenceSystemAssemblies)' == '' ">true</KSPBTReferenceSystemAssemblies>
+    <KSPBTReferenceUnityAssemblies Condition=" '$(KSPBTReferenceUnityAssemblies)' == '' ">true</KSPBTReferenceUnityAssemblies>
+    <KSPBTReferenceGameAssemblies Condition=" '$(KSPBTReferenceGameAssemblies)' == '' ">true</KSPBTReferenceGameAssemblies>
 
     <!-- Copy DLLs to mod folder -->
-    <CopyDLLsToPluginFolder Condition=" '$(CopyDLLsToPluginFolder)' == '' ">true</CopyDLLsToPluginFolder>
+    <KSPBTCopyDLLsToPluginFolder Condition=" '$(KSPBTCopyDLLsToPluginFolder)' == '' ">true</KSPBTCopyDLLsToPluginFolder>
 
 
-    <GenerateKSPAssemblyAttribute Condition=" '$(GenerateKSPAssemblyAttribute)' == '' ">true</GenerateKSPAssemblyAttribute>
+    <KSPBTGenerateAssemblyAttribute Condition=" '$(KSPBTGenerateAssemblyAttribute)' == '' ">true</KSPBTGenerateAssemblyAttribute>
 
-    <GenerateKSPAssemblyDependencyAttributes Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == '' ">true</GenerateKSPAssemblyDependencyAttributes>
+    <KSPBTGenerateDependencyAttributes Condition=" '$(KSPBTGenerateDependencyAttributes)' == '' ">true</KSPBTGenerateDependencyAttributes>
 
-    <GenerateKSPVersionFile Condition=" '$(GenerateKSPVersionFile)' == '' ">true</GenerateKSPVersionFile>
+    <KSPBTGenerateVersionFile Condition=" '$(KSPBTGenerateVersionFile)' == '' ">true</KSPBTGenerateVersionFile>
 
     <!-- default CKAN compatibility versions -->
     <CKANCompatibleVersions Condition=" '$(CKANCompatibleVersions)' == '' ">1.12 1.11 1.10 1.9 1.8</CKANCompatibleVersions>
@@ -28,32 +27,32 @@
 
   <!--Parse KSP platform-specific paths -->
   <!-- These can be overwritten by user and props files -->
-  <PropertyGroup Condition=" '$(KSPManagedRelativePath)' == '' ">
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</KSPManagedRelativePath>
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</KSPManagedRelativePath>
-    <KSPManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</KSPManagedRelativePath>
+  <PropertyGroup Condition=" '$(KSPBTManagedRelativePath)' == '' ">
+    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64_Data/Managed</KSPBTManagedRelativePath>
+    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/Resources/Data/Managed</KSPBTManagedRelativePath>
+    <KSPBTManagedRelativePath Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP_Data/Managed</KSPBTManagedRelativePath>
   </PropertyGroup>
 
   <PropertyGroup>
-    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</KSPExecutable>
-    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</KSPExecutable>
-    <KSPExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</KSPExecutable>
-    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</SteamKSPRoot>
-    <SteamKSPRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</SteamKSPRoot>
+    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">KSP_x64.exe</KSPBTGameExecutable>
+    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">KSP.app/Contents/MacOS/KSP</KSPBTGameExecutable>
+    <KSPBTGameExecutable Condition=" $([MSBuild]::IsOsPlatform('Linux')) ">KSP.x86_64</KSPBTGameExecutable>
+    <KSPBTSteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</KSPBTSteamGameRoot>
+    <KSPBTSteamGameRoot Condition=" $([MSBuild]::IsOsPlatform('OSX')) ">$(HOME)/Library/Application Support/Steam/steamapps/common/Kerbal Space Program</KSPBTSteamGameRoot>
   </PropertyGroup>
 
   <!-- Calculate mod paths -->
   <!-- These can be overwritten by user, csproj, and props files -->
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
-    <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPModRoot>
-    <!-- The folder to place resulting DLLs into, relative to KSPModRoot -->
-    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' "/>
+    <KSPBTModRoot Condition=" '$(KSPBTModRoot)' == '' ">$(MSBuildProjectDirectory)/../GameData/$(MSBuildProjectName)/</KSPBTModRoot>
+    <!-- The folder to place resulting DLLs into, relative to KSPBTModRoot -->
+    <KSPBTModPluginFolder Condition=" '$(KSPBTModPluginFolder)' == '' "/>
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->
-  <!-- This can overwrite KSPManagedRelativePath and KSPExecutable,
-       set KSPRoot and ReferencePath, and any other user-specific settings -->
+  <!-- This can overwrite KSPBTManagedRelativePath and KSPBTGameExecutable,
+       set KSPBTGameRoot and ReferencePath, and any other user-specific settings -->
   <Import Project="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
 
   <!-- Import a props.user file -->
@@ -65,55 +64,55 @@
 
   <!-- Relative path that must exist for a path to be a valid KSP Install-->
   <PropertyGroup>
-    <KSPRootIdentifier>$(KSPManagedRelativePath)/Assembly-CSharp.dll</KSPRootIdentifier>
-    <KSPRootSource Condition="'$(KSPRoot)' != ''">property</KSPRootSource>
+    <KSPBTGameIdentifier>$(KSPBTManagedRelativePath)/Assembly-CSharp.dll</KSPBTGameIdentifier>
+    <KSPBTGameRootSource Condition="'$(KSPBTGameRoot)' != ''">property</KSPBTGameRootSource>
   </PropertyGroup>
 
-  <!-- Default KSPRoot to the "KSP_ROOT" environment variable if it exists -->
+  <!-- Default KSPBTGameRoot to the "KSP_ROOT" environment variable if it exists -->
   <!-- Doing this skips any checks for a valid KSP install so be careful! -->
-  <PropertyGroup Condition=" '$(KSPRoot)' == '' And '$(KSP_ROOT)' != '' ">
-    <KSPRoot>$(KSP_ROOT)</KSPRoot>
-    <KSPRootSource>environment variable</KSPRootSource>
+  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And '$(KSP_ROOT)' != '' ">
+    <KSPBTGameRoot>$(KSP_ROOT)</KSPBTGameRoot>
+    <KSPBTGameRootSource>environment variable</KSPBTGameRootSource>
   </PropertyGroup>
   <ItemGroup>
-    <KSPRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
-    <KSPRootCandidate Include="$(ReferencePath)" source="reference path"/>
-    <KSPRootCandidate Include="$(SteamKSPRoot)" source="steam"/>
+    <KSPBTGameRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
+    <KSPBTGameRootCandidate Include="$(ReferencePath)" source="reference path"/>
+    <KSPBTGameRootCandidate Include="$(KSPBTSteamGameRoot)" source="steam"/>
   </ItemGroup>
 
   <!-- Look for KSP install in Solution dir -->
-  <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPRootIdentifier)') ">
-    <KSPRoot>$(SolutionDir)KSP</KSPRoot>
-    <KSPRootSource>solution directory</KSPRootSource>
+  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPBTGameIdentifier)') ">
+    <KSPBTGameRoot>$(SolutionDir)KSP</KSPBTGameRoot>
+    <KSPBTGameRootSource>solution directory</KSPBTGameRootSource>
   </PropertyGroup>
 
   <!-- Look for KSP install in ReferencePath -->
-  <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(ReferencePath)/$(KSPRootIdentifier)') ">
-    <KSPRoot>$(ReferencePath)</KSPRoot>
-    <KSPRootSource>reference path</KSPRootSource>
+  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(ReferencePath)/$(KSPBTGameIdentifier)') ">
+    <KSPBTGameRoot>$(ReferencePath)</KSPBTGameRoot>
+    <KSPBTGameRootSource>reference path</KSPBTGameRootSource>
   </PropertyGroup>
 
   <!-- Look for KSP steam install-->
-  <PropertyGroup Condition=" '$(KSPRoot)' == '' And Exists('$(SteamKSPRoot)/$(KSPRootIdentifier)') ">
-    <KSPRoot>$(SteamKSPRoot)</KSPRoot>
-    <KSPRootSource>steam</KSPRootSource>
+  <PropertyGroup Condition=" '$(KSPBTGameRoot)' == '' And Exists('$(KSPBTSteamGameRoot)/$(KSPBTGameIdentifier)') ">
+    <KSPBTGameRoot>$(KSPBTSteamGameRoot)</KSPBTGameRoot>
+    <KSPBTGameRootSource>steam</KSPBTGameRootSource>
   </PropertyGroup>
 
-  <!-- Calculate ManagedPath -->
-  <PropertyGroup Condition=" '$(ManagedPath)' == ''">
-    <ManagedPath>$(KSPRoot)/$(KSPManagedRelativePath)</ManagedPath>
+  <!-- Calculate KSPBTManagedPath -->
+  <PropertyGroup Condition=" '$(KSPBTManagedPath)' == ''">
+    <KSPBTManagedPath>$(KSPBTGameRoot)/$(KSPBTManagedRelativePath)</KSPBTManagedPath>
   </PropertyGroup>
 
   <!-- set the start action so that you can launch directly from VS -->
   <PropertyGroup>
     <StartAction>Program</StartAction>
-    <StartProgram>$(KSPRoot)/$(KSPExecutable)</StartProgram>
-    <StartWorkingDirectory>$(KSPRoot)</StartWorkingDirectory>
+    <StartProgram>$(KSPBTGameRoot)/$(KSPBTGameExecutable)</StartProgram>
+    <StartWorkingDirectory>$(KSPBTGameRoot)</StartWorkingDirectory>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
+  <PropertyGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
     <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <!-- Instruct the compiler to not automatically reference mscorlib -->
@@ -121,42 +120,42 @@
     <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
          from attempting to locate an external copy of the reference assemblies. -->
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(ManagedPath)</FrameworkPathOverride>
+    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
 
   <!-- Import references -->
-  <ItemGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/System.dll">
+  <ItemGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/System.dll">
       <Name>System (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(ManagedPath)/System.Core.dll">
+    <Reference Include="$(KSPBTManagedPath)/System.Core.dll">
       <Name>System (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(ManagedPath)/mscorlib.dll">
+    <Reference Include="$(KSPBTManagedPath)/mscorlib.dll">
       <Name>System.Core (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(ManagedPath)/System.Xml.dll">
+    <Reference Include="$(KSPBTManagedPath)/System.Xml.dll">
       <Name>System.Xml (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceKSPUnityAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/UnityEngine*.dll">
+  <ItemGroup Condition=" '$(KSPBTReferenceUnityAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/UnityEngine*.dll">
       <Name>UnityEngine</Name>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceKSPGameAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/Assembly-CSharp.dll">
+  <ItemGroup Condition=" '$(KSPBTReferenceGameAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp.dll">
       <Name>Assembly-CSharp</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(ManagedPath)/Assembly-CSharp-firstpass.dll">
+    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp-firstpass.dll">
       <Name>Assembly-CSharp-firstpass</Name>
       <Private>False</Private>
     </Reference>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -112,6 +112,18 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup>
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -111,57 +111,6 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
-
-  <!-- Import references -->
-  <ItemGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/System.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(KSPBTManagedPath)/System.Core.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(KSPBTManagedPath)/mscorlib.dll">
-      <Name>System.Core (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(KSPBTManagedPath)/System.Xml.dll">
-      <Name>System.Xml (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(KSPBTReferenceUnityAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/UnityEngine*.dll">
-      <Name>UnityEngine</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(KSPBTReferenceGameAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp.dll">
-      <Name>Assembly-CSharp</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp-firstpass.dll">
-      <Name>Assembly-CSharp-firstpass</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-
-
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)/include/*.cs" Condition="exists('$(MSBuildThisFileDirectory)/include')"/>
   </ItemGroup>

--- a/KSPCommon.props
+++ b/KSPCommon.props
@@ -47,7 +47,8 @@
   <PropertyGroup>
     <!-- The root directory of the mod, the folder that gets placed in GameData -->
     <KSPModRoot Condition=" '$(KSPModRoot)' == '' ">$(ProjectDir)/../GameData/$(ProjectName)/</KSPModRoot>
-    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' ">$(KSPModGameData)/Plugins/</KSPModPluginFolder>
+    <!-- The folder to place resulting DLLs into, relative to KSPModRoot -->
+    <KSPModPluginFolder Condition=" '$(KSPModPluginFolder)' == '' "/>
   </PropertyGroup>
 
   <!-- Import the csproj.user file. -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -4,7 +4,7 @@
 
   <!-- Calculate KSPBT_ManagedPath -->
   <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
-    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
+    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
   <!-- Import references -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -7,57 +7,6 @@
     <!-- For GenerateKSPVersionFile -->
     <PackageReference Include="JsonPoke" Version="1.2.0" Condition="'@(KSPVersionFile)' != ''"/>
   </ItemGroup>
-
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(ManagedPath)</FrameworkPathOverride>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
-  <!-- Import references -->
-  <ItemGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/System.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)/System.Core.dll">
-      <Name>System (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)/mscorlib.dll">
-      <Name>System.Core (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)/System.Xml.dll">
-      <Name>System.Xml (KSP/Mono)</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceKSPUnityAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/UnityEngine*.dll">
-      <Name>UnityEngine</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(ReferenceKSPGameAssemblies)' == 'true' ">
-    <Reference Include="$(ManagedPath)/Assembly-CSharp.dll">
-      <Name>Assembly-CSharp</Name>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="$(ManagedPath)/Assembly-CSharp-firstpass.dll">
-      <Name>Assembly-CSharp-firstpass</Name>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-
-
   <!--Custom Targets-->
   <Target Name="CheckForKSPRoot" BeforeTargets="ResolveReferences">
     <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPRoot property

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -116,7 +116,7 @@
 
   <!-- Execute generated CKAN command list -->
   <Target Name="CKANInstall" DependsOnTargets="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences" Inputs="$(CKANCommandFile)" Outputs="$(KSPBTGameRoot)/CKAN/registry.json">
-    <Exec Command="ckan prompt --headless &lt; '$(CKANCommandFile)'" Condition="'$(CKANDependencyList)' != ''"/>
+    <Exec Command="ckan prompt --headless &lt; '$(CKANCommandFile)'" Condition="'$(_CKANDependencyList)' != ''"/>
   </Target>
 
   <Target Name="CKANClean" AfterTargets="Clean">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -61,6 +61,7 @@
 
   <ItemGroup>
     <ResolveAssemblyReferencesDependsOn Include="CKANInstall"/>
+    <ResolveAssemblyReferencesDependsOn Include="KSPBTGenerateAssemblyReferences"/>
   </ItemGroup>
 
   <!-- Execute generated CKAN command list -->
@@ -71,6 +72,23 @@
   <Target Name="CKANClean" AfterTargets="Clean">
     <Delete Files="$(CKANCommandFile)"/>
   </Target>
+
+  <!--
+  Convert ModReference items to Reference items. This allows KSPBTInstallRoot to be evaluated
+  after the csproj body or in a target, giving greater flexibility.
+
+  The value of the item should be name of the assembly as defined in its KSPAssembly attribute.
+  The DLLPath attribute is the path to the DLL relative to the installation root, e.g. "GameData/CoolMod/mod.dll"
+  -->
+  <Target Name="KSPBTGenerateAssemblyReferences" BeforeTargets="ResolveAssemblyReferences"
+          Inputs="@(ModReference)" Outputs="@(Reference)">
+    <ItemGroup>
+      <Reference Include="@(ModReference->'$(KSPBTGameRoot)/%(DLLPath)')">
+        <KSPAssemblyName>%(ModReference.identity)</KSPAssemblyName>
+      </Reference>
+    </ItemGroup>
+  </Target>
+
 
   <!--  For use like so: `msbuild -t:"GetRequiredExternalTools" -verbosity:minimal -nologo`, then pipe into your destination of choice -->
   <Target Name="GetRequiredExternalTools">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -103,12 +103,6 @@
     </Reference>
   </ItemGroup>
 
-  <!-- NuGet dependencies -->
-  <ItemGroup>
-    <!-- For KSPBT_GenerateVersionFile -->
-    <PackageReference Include="JsonPoke" Version="1.2.0" Condition="'@(KSPVersionFile)' != ''"/>
-  </ItemGroup>
-
   <!--Custom Targets-->
   <Target Name="KSPBT_CheckForGameRoot" BeforeTargets="ResolveReferences">
     <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPBT_GameRoot property
@@ -124,22 +118,33 @@
     <Message Text="@(_GameRootMessage, '%0a')" Importance="normal"/>
   </Target>
 
-  <!-- Copy DLLs to mod GameData folder-->
-  <Target Name="KSPBT_CopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
-          Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == 'true'">
+  <!--
+  Convert ModReference items to Reference items. This allows KSPBT_InstallRoot to be evaluated
+  after the csproj body or in a target, giving greater flexibility.
+
+  The value of the item should be name of the assembly as defined in its KSPAssembly attribute.
+  The DLLPath attribute is the path to the DLL relative to the installation root, e.g. "GameData/CoolMod/mod.dll"
+  -->
+  <PropertyGroup Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
+    <ResolveAssemblyReferencesDependsOn>KSPBT_ReferenceModAssemblies;$(ResolveAssemblyReferencesDependsOn)</ResolveAssemblyReferencesDependsOn>
+    <KSPBT_GenerateCKANScriptDependsOn>KSPBT_ReferenceModAssemblies;$(KSPBT_GenerateCKANScriptDependsOn)</KSPBT_GenerateCKANScriptDependsOn>
+  </PropertyGroup>
+  <Target Name="KSPBT_ReferenceModAssemblies" BeforeTargets="ResolveAssemblyReferences"
+          Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
     <ItemGroup>
-      <_BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
-      <_BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
+      <Reference Include="@(ModReference->'$(KSPBT_GameRoot)/%(DLLPath)')">
+        <KSPAssemblyName>%(ModReference.identity)</KSPAssemblyName>
+      </Reference>
     </ItemGroup>
-    <MakeDir Directories="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)"/>
-    <Copy SourceFiles="@(_BinariesToCopy)" DestinationFolder="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)/%(RecursiveDir)"/>
   </Target>
+
+
 
   <!-- Generate script to run to install CKAN dependencies -->
   <PropertyGroup>
     <_CKANScript>$(BaseIntermediateOutputPath)ckancommands.cache</_CKANScript>
   </PropertyGroup>
-  <Target Name="KSPBT_GenerateCKANScript">
+  <Target Name="KSPBT_GenerateCKANScript" DependsOnTargets="$(KSPBT_GenerateCKANScriptDependsOn)">
     <ItemGroup>
       <_CKANCompatibleVersionItems Include="$(KSPBT_CKANCompatibleVersions.Split(' '))"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="'%(Reference.CKANVersion)' == ''"/>
@@ -162,9 +167,9 @@
   </Target>
 
   <!-- Execute generated CKAN command list -->
-  <ItemGroup Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
-    <ResolveAssemblyReferencesDependsOn Include="KSPBT_InstallCKANDependencies"/>
-  </ItemGroup>
+  <PropertyGroup Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
+    <ResolveAssemblyReferencesDependsOn>KSPBT_InstallCKANDependencies;$(ResolveAssemblyReferencesDependsOn)</ResolveAssemblyReferencesDependsOn>
+  </PropertyGroup>
   <Target Name="KSPBT_InstallCKANDependencies" DependsOnTargets="KSPBT_GenerateCKANScript" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences"
           Inputs="$(_CKANScript)" Outputs="$(KSPBT_GameRoot)/CKAN/registry.json"
           Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
@@ -173,26 +178,6 @@
 
   <Target Name="KSPBT_CleanCKANScript" AfterTargets="Clean">
     <Delete Files="$(_CKANScript)"/>
-  </Target>
-
-  <!--
-  Convert ModReference items to Reference items. This allows KSPBT_InstallRoot to be evaluated
-  after the csproj body or in a target, giving greater flexibility.
-
-  The value of the item should be name of the assembly as defined in its KSPAssembly attribute.
-  The DLLPath attribute is the path to the DLL relative to the installation root, e.g. "GameData/CoolMod/mod.dll"
-  -->
-  <ItemGroup Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
-    <ResolveAssemblyReferencesDependsOn Include="KSPBT_ReferenceModAssemblies"/>
-  </ItemGroup>
-  <Target Name="KSPBT_ReferenceModAssemblies" BeforeTargets="ResolveAssemblyReferences"
-          Inputs="@(ModReference)" Outputs="@(Reference)"
-          Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
-    <ItemGroup>
-      <Reference Include="@(ModReference->'$(KSPBT_GameRoot)/%(DLLPath)')">
-        <KSPAssemblyName>%(ModReference.identity)</KSPAssemblyName>
-      </Reference>
-    </ItemGroup>
   </Target>
 
   <!-- Generate the KSPAssembly attribute based on the FileVersion property -->
@@ -308,5 +293,16 @@
 
     <Message Text="Writing JSON version file to %(KSPVersionFile.Destination)"/>
     <Message Text="Contents:%0a$(_JSON)" Importance="low"/>
+  </Target>
+
+  <!-- Copy DLLs to mod GameData folder-->
+  <Target Name="KSPBT_CopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
+          Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == 'true'">
+    <ItemGroup>
+      <_BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
+      <_BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
+    </ItemGroup>
+    <MakeDir Directories="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)"/>
+    <Copy SourceFiles="@(_BinariesToCopy)" DestinationFolder="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)/%(RecursiveDir)"/>
   </Target>
 </Project>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -7,6 +7,19 @@
     <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup>
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <!-- Import references -->
   <ItemGroup Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == 'true' ">
     <Reference Include="$(KSPBT_ManagedPath)/System.dll">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -32,7 +32,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(KSPBT_ReferenceGameAssemblies)' == 'true' and '$(Configuration)' == 'Unity'">
+  <ItemGroup Condition=" '$(KSPBT_ReferenceGameAssemblies)' == 'true'">
     <Reference Include="$(KSPBT_ManagedPath)/Assembly-CSharp.dll">
       <Name>Assembly-CSharp</Name>
       <Private>False</Private>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -4,7 +4,7 @@
 
   <!-- Calculate KSPBT_ManagedPath -->
   <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
-    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
+    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
   <!-- Import references -->
@@ -81,7 +81,7 @@
   </PropertyGroup>
   <Target Name="KSPBT_GenerateCKANScript">
     <ItemGroup>
-      <_CKANCompatibleVersionItems Include="$(KSPBT_KSPBT_CKANCompatibleVersions.Split(' '))"/>
+      <_CKANCompatibleVersionItems Include="$(KSPBT_CKANCompatibleVersions.Split(' '))"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="'%(Reference.CKANVersion)' == ''"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)=%(Reference.CKANVersion)" Condition="'%(Reference.CKANVersion)' != ''"/>
       <_CKANDependency Include="@(CKANDependency)"/>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,11 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
-  <!-- Calculate KSPBT_ManagedPath -->
-  <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
-    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
-  </PropertyGroup>
-
   <!-- Import references -->
   <ItemGroup Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == 'true' ">
     <Reference Include="$(KSPBT_ManagedPath)/System.dll">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -8,8 +8,57 @@
     <PackageReference Include="JsonPoke" Version="1.2.0" Condition="'@(KSPVersionFile)' != ''"/>
   </ItemGroup>
 
-  <!--Custom Targets-->
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' != 'true' ">>
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <FrameworkPathOverride>$(ManagedPath)</FrameworkPathOverride>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
 
+  <!-- Import references -->
+  <ItemGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/System.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/System.Core.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/mscorlib.dll">
+      <Name>System.Core (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/System.Xml.dll">
+      <Name>System.Xml (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceKSPUnityAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/UnityEngine*.dll">
+      <Name>UnityEngine</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(ReferenceKSPGameAssemblies)' == 'true' ">
+    <Reference Include="$(ManagedPath)/Assembly-CSharp.dll">
+      <Name>Assembly-CSharp</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(ManagedPath)/Assembly-CSharp-firstpass.dll">
+      <Name>Assembly-CSharp-firstpass</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+
+  <!--Custom Targets-->
   <Target Name="CheckForKSPRoot" BeforeTargets="ResolveReferences">
     <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPRoot property
                  in your csproj.user file to a valid KSP installation directory (the one with GameData in it)
@@ -22,16 +71,17 @@
       <_KSPRootMessage Include="Chosen KSPRoot: $(KSPRoot) in $(KSPRootSource)" Condition="'$(KSPRoot)' != ''"/>
     </ItemGroup>
     <Message Text="@(_KSPRootMessage, '%0a')" Importance="normal"/>
-
   </Target>
 
-  <!-- Copy output files to mod folder -->
-  <Target Name="CopyBinariesToRepo" AfterTargets="CopyFilesToOutputDirectory">
+  <!-- Copy DLLs to mod GameData folder-->
+  <Target Name="CopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
+          Condition="'$(CopyDLLsToPluginFolder)' == 'true'">
     <ItemGroup>
-      <BinariesToCopy Include="$(TargetDir)/**"/>
+      <BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
+      <BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
     </ItemGroup>
-    <MakeDir Directories="$(RepoRootPath)/$(BinariesOutputRelativePath)"/>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(RepoRootPath)/$(BinariesOutputRelativePath)/%(RecursiveDir)"/>
+    <MakeDir Directories="$(KSPModPluginFolder)"/>
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(KSPModPluginFolder)/%(RecursiveDir)"/>
   </Target>
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
@@ -82,9 +132,7 @@
     <Message Text="@(RequiredExternalTool)" Importance="high"/>
   </Target>
 
-  <!--
-  Generate the KSPAssembly attribute based on the FileVersion property
-  -->
+  <!-- Generate the KSPAssembly attribute based on the FileVersion property -->
   <Target Name="GenerateKSPAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
           Condition="'$(GenerateKSPAssemblyAttribute)' == 'true'">
     <ItemGroup>
@@ -110,7 +158,7 @@
     Otherwise 0.0 is used (no minimum version)
   -->
   <Target Name="GenerateKSPAssemblyDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition="'$(GenerateKSPAssemblyDependencyAttributes)' == 'true'">
+          Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == 'true' ">
     <ItemGroup>
       <Reference Update="%(Reference.identity)" Condition="'%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != ''">
         <KSPAssemblyName Condition="'%(Reference.KSPAssemblyName)' == ''">$([System.String]::Copy('%(Reference.identity)').Split(',')[0])</KSPAssemblyName>
@@ -156,7 +204,9 @@
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="GenerateKSPVersionFile" AfterTargets="Build" Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)">
+  <Target Name="GenerateKSPVersionFile" AfterTargets="Build"
+          Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)"
+          Condition= " '$(GenerateKSPVersionFile)' == 'true' ">
     <ItemGroup>
       <KSPVersionFile Update="@(KSPVersionFile)">
         <Name Condition="'%(KSPVersionFile.Name)' == ''">$(ProjectName)</Name>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -7,6 +7,8 @@
     <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
+  <Target Name="GetReferenceAssemblyPaths" />                 <!-- Don't go looking for framewoek reference assemblies-->
+
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
   <PropertyGroup>
     <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,37 +2,42 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
+  <!-- Calculate KSPBT_ManagedPath -->
+  <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
+    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(_KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
+  </PropertyGroup>
+
   <!-- Import references -->
-  <ItemGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/System.dll">
+  <ItemGroup Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBT_ManagedPath)/System.dll">
       <Name>System (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(KSPBTManagedPath)/System.Core.dll">
+    <Reference Include="$(KSPBT_ManagedPath)/System.Core.dll">
       <Name>System (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(KSPBTManagedPath)/mscorlib.dll">
+    <Reference Include="$(KSPBT_ManagedPath)/mscorlib.dll">
       <Name>System.Core (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(KSPBTManagedPath)/System.Xml.dll">
+    <Reference Include="$(KSPBT_ManagedPath)/System.Xml.dll">
       <Name>System.Xml (KSP/Mono)</Name>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(KSPBTReferenceUnityAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/UnityEngine*.dll">
+  <ItemGroup Condition=" '$(KSPBT_ReferenceUnityAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBT_ManagedPath)/UnityEngine*.dll">
       <Name>UnityEngine</Name>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(KSPBTReferenceGameAssemblies)' == 'true' ">
-    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp.dll">
+  <ItemGroup Condition=" '$(KSPBT_ReferenceGameAssemblies)' == 'true' and '$(Configuration)' == 'Unity'">
+    <Reference Include="$(KSPBT_ManagedPath)/Assembly-CSharp.dll">
       <Name>Assembly-CSharp</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp-firstpass.dll">
+    <Reference Include="$(KSPBT_ManagedPath)/Assembly-CSharp-firstpass.dll">
       <Name>Assembly-CSharp-firstpass</Name>
       <Private>False</Private>
     </Reference>
@@ -40,42 +45,43 @@
 
   <!-- NuGet dependencies -->
   <ItemGroup>
-    <!-- For KSPBTGenerateVersionFile -->
+    <!-- For KSPBT_GenerateVersionFile -->
     <PackageReference Include="JsonPoke" Version="1.2.0" Condition="'@(KSPVersionFile)' != ''"/>
   </ItemGroup>
+
   <!--Custom Targets-->
-  <Target Name="KSPBTCheckForGameRoot" BeforeTargets="ResolveReferences">
-    <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPBTGameRoot property
+  <Target Name="KSPBT_CheckForGameRoot" BeforeTargets="ResolveReferences">
+    <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPBT_GameRoot property
                  in your csproj.user file to a valid KSP installation directory (the one with GameData in it)
 
                  See https://kspbuildtools.readthedocs.io/en/latest/msbuild/getting-started.html#locating-your-ksp-install for more information"
-           Condition="'$(KSPBTGameRoot)' == ''"/>
+           Condition="'$(KSPBT_GameRoot)' == ''"/>
     <ItemGroup>
-      <_GameRootMessage Include="KSPBTGameRoot Candidates:"/>
-      <_GameRootMessage Include="Candidate: %(KSPBTGameRootCandidate.source) from %(KSPBTGameRootCandidate.identity)"/>
-      <_GameRootMessage Include="Chosen KSPBTGameRoot: $(KSPBTGameRoot) in $(KSPBTGameRootSource)" Condition="'$(KSPBTGameRoot)' != ''"/>
+      <_GameRootMessage Include="KSPBT_GameRoot Candidates:"/>
+      <_GameRootMessage Include="Candidate: %(KSPBT_GameRootCandidate.source) from %(KSPBT_GameRootCandidate.identity)"/>
+      <_GameRootMessage Include="Chosen KSPBT_GameRoot: $(KSPBT_GameRoot) in $(KSPBT_GameRootSource)" Condition="'$(KSPBT_GameRoot)' != ''"/>
     </ItemGroup>
     <Message Text="@(_GameRootMessage, '%0a')" Importance="normal"/>
   </Target>
 
   <!-- Copy DLLs to mod GameData folder-->
-  <Target Name="KSPBTCopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(KSPBTCopyDLLsToPluginFolder)' == 'true'">
+  <Target Name="KSPBT_CopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
+          Condition=" '$(KSPBT_CopyDLLsToPluginFolder)' == 'true'">
     <ItemGroup>
       <_BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
       <_BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
     </ItemGroup>
-    <MakeDir Directories="$(KSPBTModRoot)/$(KSPBTModPluginFolder)"/>
-    <Copy SourceFiles="@(_BinariesToCopy)" DestinationFolder="$(KSPBTModRoot)/$(KSPBTModPluginFolder)/%(RecursiveDir)"/>
+    <MakeDir Directories="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)"/>
+    <Copy SourceFiles="@(_BinariesToCopy)" DestinationFolder="$(KSPBT_ModRoot)/$(KSPBT_ModPluginFolder)/%(RecursiveDir)"/>
   </Target>
 
-  <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
+  <!-- Generate script to run to install CKAN dependencies -->
   <PropertyGroup>
-    <CKANCommandFile>$(BaseIntermediateOutputPath)ckancommands.cache</CKANCommandFile>
+    <_CKANScript>$(BaseIntermediateOutputPath)ckancommands.cache</_CKANScript>
   </PropertyGroup>
-  <Target Name="CKANInstallScriptGen">
+  <Target Name="KSPBT_GenerateCKANScript">
     <ItemGroup>
-      <_CKANCompatibleVersionItems Include="$(CKANCompatibleVersions.Split(' '))"/>
+      <_CKANCompatibleVersionItems Include="$(KSPBT_KSPBT_CKANCompatibleVersions.Split(' '))"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)" Condition="'%(Reference.CKANVersion)' == ''"/>
       <_CKANDependency Include="%(Reference.CKANIdentifier)=%(Reference.CKANVersion)" Condition="'%(Reference.CKANVersion)' != ''"/>
       <_CKANDependency Include="@(CKANDependency)"/>
@@ -85,59 +91,53 @@
     </PropertyGroup>
     <ItemGroup>
       <!-- Not using `ckan compat set` because as of 2024-08-16 it is still only available in the dev branch -->
-      <_CKANCommands Include="compat add --gamedir &quot;$(KSPBTGameRoot)&quot; %(_CKANCompatibleVersionItems.Identity)"
-                     Condition=" '$(CKANCompatibleVersions)' != '' "/>
+      <_CKANCommands Include="compat add --gamedir &quot;$(KSPBT_GameRoot)&quot; %(_CKANCompatibleVersionItems.Identity)"
+                     Condition=" '$(KSPBT_CKANCompatibleVersions)' != '' "/>
 
-      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPBTGameRoot)&quot; $(_CKANDependencyList)" Condition="'$(CKANDependencyList)' != ''"/>
+      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPBT_GameRoot)&quot; $(_CKANDependencyList)" Condition="'$(CKANDependencyList)' != ''"/>
     </ItemGroup>
-    <Message Text="Writing CKAN commands to $(CKANCommandFile)"/>
+    <Message Text="Writing CKAN commands to $(_CKANScript)"/>
     <Message Text="@(_CKANCommands, '%0a')" Importance="Low"/>
-    <WriteLinesToFile File="$(CKANCommandFile)" Lines="@(_CKANCommands)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
+    <WriteLinesToFile File="$(_CKANScript)" Lines="@(_CKANCommands)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>
-
-  <ItemGroup>
-    <ResolveAssemblyReferencesDependsOn Include="CKANInstall"/>
-    <ResolveAssemblyReferencesDependsOn Include="KSPBTGenerateAssemblyReferences"/>
-  </ItemGroup>
 
   <!-- Execute generated CKAN command list -->
-  <Target Name="CKANInstall" DependsOnTargets="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences" Inputs="$(CKANCommandFile)" Outputs="$(KSPBTGameRoot)/CKAN/registry.json">
-    <Exec Command="ckan prompt --headless &lt; '$(CKANCommandFile)'" Condition="'$(_CKANDependencyList)' != ''"/>
+  <ItemGroup Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
+    <ResolveAssemblyReferencesDependsOn Include="KSPBT_InstallCKANDependencies"/>
+  </ItemGroup>
+  <Target Name="KSPBT_InstallCKANDependencies" DependsOnTargets="KSPBT_GenerateCKANScript" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences"
+          Inputs="$(_CKANScript)" Outputs="$(KSPBT_GameRoot)/CKAN/registry.json"
+          Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
+    <Exec Command="ckan prompt --headless &lt; '$(_CKANScript)" Condition=" '$(_CKANDependencyList)' != '' "/>
   </Target>
 
-  <Target Name="CKANClean" AfterTargets="Clean">
-    <Delete Files="$(CKANCommandFile)"/>
+  <Target Name="KSPBT_CleanCKANScript" AfterTargets="Clean">
+    <Delete Files="$(_CKANScript)"/>
   </Target>
 
   <!--
-  Convert ModReference items to Reference items. This allows KSPBTInstallRoot to be evaluated
+  Convert ModReference items to Reference items. This allows KSPBT_InstallRoot to be evaluated
   after the csproj body or in a target, giving greater flexibility.
 
   The value of the item should be name of the assembly as defined in its KSPAssembly attribute.
   The DLLPath attribute is the path to the DLL relative to the installation root, e.g. "GameData/CoolMod/mod.dll"
   -->
-  <Target Name="KSPBTGenerateAssemblyReferences" BeforeTargets="ResolveAssemblyReferences"
-          Inputs="@(ModReference)" Outputs="@(Reference)">
+  <ItemGroup Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
+    <ResolveAssemblyReferencesDependsOn Include="KSPBT_ReferenceModAssemblies"/>
+  </ItemGroup>
+  <Target Name="KSPBT_ReferenceModAssemblies" BeforeTargets="ResolveAssemblyReferences"
+          Inputs="@(ModReference)" Outputs="@(Reference)"
+          Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
     <ItemGroup>
-      <Reference Include="@(ModReference->'$(KSPBTGameRoot)/%(DLLPath)')">
+      <Reference Include="@(ModReference->'$(KSPBT_GameRoot)/%(DLLPath)')">
         <KSPAssemblyName>%(ModReference.identity)</KSPAssemblyName>
       </Reference>
     </ItemGroup>
   </Target>
 
-
-  <!--  For use like so: `msbuild -t:"GetRequiredExternalTools" -verbosity:minimal -nologo`, then pipe into your destination of choice -->
-  <Target Name="GetRequiredExternalTools">
-    <ItemGroup>
-      <CKANDependencyList Include="%(Reference.CKANIdentifier)"/>
-      <RequiredExternalTool Include="CKAN" Condition="'@(CKANDependencyList)' != ''"/>
-    </ItemGroup>
-    <Message Text="@(RequiredExternalTool)" Importance="high"/>
-  </Target>
-
   <!-- Generate the KSPAssembly attribute based on the FileVersion property -->
-  <Target Name="KSPBTGenerateAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition="'$(KSPBTGenerateAssemblyAttribute)' == 'true'">
+  <Target Name="KSPBT_GenerateAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition="'$(KSPBT_GenerateAssemblyAttribute)' == 'true'">
     <ItemGroup>
       <AssemblyAttribute Include="KSPAssembly">
         <_Parameter1>$(AssemblyName)</_Parameter1>
@@ -160,8 +160,8 @@
     Otherwise CKANVersion is used.
     Otherwise 0.0 is used (no minimum version)
   -->
-  <Target Name="KSPBTGenerateDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition=" '$(KSPBTGenerateDependencyAttributes)' == 'true' ">
+  <Target Name="KSPBT_GenerateDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition=" '$(KSPBT_GenerateDependencyAttributes)' == 'true' ">
     <ItemGroup>
       <Reference Update="%(Reference.identity)" Condition="'%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != ''">
         <KSPAssemblyName Condition="'%(Reference.KSPAssemblyName)' == ''">$([System.String]::Copy('%(Reference.identity)').Split(',')[0])</KSPAssemblyName>
@@ -207,9 +207,9 @@
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="KSPBTGenerateVersionFile" AfterTargets="Build"
+  <Target Name="KSPBT_GenerateVersionFile" AfterTargets="Build"
           Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)"
-          Condition= " '$(KSPBTGenerateVersionFile)' == 'true' ">
+          Condition=" '$(KSPBT_GenerateVersionFile)' == 'true' ">
     <ItemGroup>
       <KSPVersionFile Update="@(KSPVersionFile)">
         <Name Condition="'%(KSPVersionFile.Name)' == ''">$(ProjectName)</Name>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -9,15 +9,7 @@
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
   <PropertyGroup>
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
     <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <!-- Import references -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,6 +2,56 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
+  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
+  <PropertyGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+
+  <!-- Import references -->
+  <ItemGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/System.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPBTManagedPath)/System.Core.dll">
+      <Name>System (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPBTManagedPath)/mscorlib.dll">
+      <Name>System.Core (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPBTManagedPath)/System.Xml.dll">
+      <Name>System.Xml (KSP/Mono)</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(KSPBTReferenceUnityAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/UnityEngine*.dll">
+      <Name>UnityEngine</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(KSPBTReferenceGameAssemblies)' == 'true' ">
+    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp.dll">
+      <Name>Assembly-CSharp</Name>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="$(KSPBTManagedPath)/Assembly-CSharp-firstpass.dll">
+      <Name>Assembly-CSharp-firstpass</Name>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
   <!-- NuGet dependencies -->
   <ItemGroup>
     <!-- For KSPBTGenerateVersionFile -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -133,7 +133,7 @@
           Condition=" '$(KSPBT_ReferenceModAssemblies)' == 'true' ">
     <ItemGroup>
       <Reference Include="@(ModReference->'$(KSPBT_GameRoot)/%(DLLPath)')">
-        <KSPAssemblyName>%(ModReference.identity)</KSPAssemblyName>
+        <KSPAssemblyName Condition=" '%(ModReference.KSPAssemblyName' == '' ">%(ModReference.identity)</KSPAssemblyName>
       </Reference>
     </ItemGroup>
   </Target>
@@ -208,7 +208,7 @@
   <Target Name="KSPBT_GenerateDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
           Condition=" '$(KSPBT_GenerateDependencyAttributes)' == 'true' ">
     <ItemGroup>
-      <Reference Update="%(Reference.identity)" Condition="'%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != ''">
+      <Reference Update="%(Reference.identity)" Condition=" '%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != '' and '%(Reference.GenerateDependencyAttribute)' == 'true' ">
         <KSPAssemblyName Condition="'%(Reference.KSPAssemblyName)' == ''">$([System.String]::Copy('%(Reference.identity)').Split(',')[0])</KSPAssemblyName>
         <KSPAssemblyVersion Condition="'%(Reference.KSPAssemblyVersion)' == ''">%(Reference.CKANVersion)</KSPAssemblyVersion>
         <KSPAssemblyVersion Condition="'%(Reference.KSPAssemblyVersion)' == ''">0.0</KSPAssemblyVersion>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -7,8 +7,6 @@
     <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
   </PropertyGroup>
 
-  <Target Name="GetReferenceAssemblyPaths" />                 <!-- Don't go looking for framewoek reference assemblies-->
-
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
   <PropertyGroup>
     <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
@@ -20,6 +18,8 @@
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
+    <_FullFrameworkReferenceAssemblyPaths>$(KSPBT_ManagedPath)</_FullFrameworkReferenceAssemblyPaths>
+    <_TargetFrameworkDirectories>$(KSPBT_ManagedPath)</_TargetFrameworkDirectories>
   </PropertyGroup>
 
   <!-- Import references -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -11,6 +11,14 @@
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
   <PropertyGroup>
+    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+    <!-- Instruct the compiler to not automatically reference mscorlib -->
+    <NoStandardLib>true</NoStandardLib>
+    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
+         from attempting to locate an external copy of the reference assemblies. -->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <FrameworkPathOverride>$(KSPBT_ManagedPath)</FrameworkPathOverride>
   </PropertyGroup>
 

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -53,7 +53,7 @@
   </PropertyGroup>
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == 'true' ">
     <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <!-- Instruct the compiler to not automatically reference mscorlib -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -29,8 +29,8 @@
       <BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
       <BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
     </ItemGroup>
-    <MakeDir Directories="$(KSPModPluginFolder)"/>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(KSPModPluginFolder)/%(RecursiveDir)"/>
+    <MakeDir Directories="$(KSPModRoot)/$(KSPModPluginFolder)"/>
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(KSPModRoot)/$(KSPModPluginFolder)/%(RecursiveDir)"/>
   </Target>
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -108,7 +108,7 @@
   <Target Name="KSPBT_InstallCKANDependencies" DependsOnTargets="KSPBT_GenerateCKANScript" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences"
           Inputs="$(_CKANScript)" Outputs="$(KSPBT_GameRoot)/CKAN/registry.json"
           Condition=" '$(KSPBT_InstallCKANDependencies)' == 'true' ">
-    <Exec Command="ckan prompt --headless &lt; '$(_CKANScript)" Condition=" '$(_CKANDependencyList)' != '' "/>
+    <Exec Command="ckan prompt --headless &lt; '$(_CKANScript)'" Condition=" '$(_CKANDependencyList)' != '' "/>
   </Target>
 
   <Target Name="KSPBT_CleanCKANScript" AfterTargets="Clean">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -4,33 +4,33 @@
 
   <!-- NuGet dependencies -->
   <ItemGroup>
-    <!-- For GenerateKSPVersionFile -->
+    <!-- For KSPBTGenerateVersionFile -->
     <PackageReference Include="JsonPoke" Version="1.2.0" Condition="'@(KSPVersionFile)' != ''"/>
   </ItemGroup>
   <!--Custom Targets-->
-  <Target Name="CheckForKSPRoot" BeforeTargets="ResolveReferences">
-    <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPRoot property
+  <Target Name="KSPBTCheckForGameRoot" BeforeTargets="ResolveReferences">
+    <Error Text="KSPBuildTools was unable to find a KSP installation. Please set the ReferencePath or KSPBTGameRoot property
                  in your csproj.user file to a valid KSP installation directory (the one with GameData in it)
 
                  See https://kspbuildtools.readthedocs.io/en/latest/msbuild/getting-started.html#locating-your-ksp-install for more information"
-           Condition="'$(KSPRoot)' == ''"/>
+           Condition="'$(KSPBTGameRoot)' == ''"/>
     <ItemGroup>
-      <_KSPRootMessage Include="KSPRoot Candidates:"/>
-      <_KSPRootMessage Include="Candidate: %(KSPRootCandidate.source) from %(KSPRootCandidate.identity)"/>
-      <_KSPRootMessage Include="Chosen KSPRoot: $(KSPRoot) in $(KSPRootSource)" Condition="'$(KSPRoot)' != ''"/>
+      <_GameRootMessage Include="KSPBTGameRoot Candidates:"/>
+      <_GameRootMessage Include="Candidate: %(KSPBTGameRootCandidate.source) from %(KSPBTGameRootCandidate.identity)"/>
+      <_GameRootMessage Include="Chosen KSPBTGameRoot: $(KSPBTGameRoot) in $(KSPBTGameRootSource)" Condition="'$(KSPBTGameRoot)' != ''"/>
     </ItemGroup>
-    <Message Text="@(_KSPRootMessage, '%0a')" Importance="normal"/>
+    <Message Text="@(_GameRootMessage, '%0a')" Importance="normal"/>
   </Target>
 
   <!-- Copy DLLs to mod GameData folder-->
-  <Target Name="CopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(CopyDLLsToPluginFolder)' == 'true'">
+  <Target Name="KSPBTCopyDLLsToPluginFolder" AfterTargets="CopyFilesToOutputDirectory"
+          Condition="'$(KSPBTCopyDLLsToPluginFolder)' == 'true'">
     <ItemGroup>
-      <BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
-      <BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
+      <_BinariesToCopy Include="$(TargetDir)/**/*.dll"/>
+      <_BinariesToCopy Include="$(TargetDir)/**/*.pdb" Condition="'$(Condition)' == 'Debug'"/>
     </ItemGroup>
-    <MakeDir Directories="$(KSPModRoot)/$(KSPModPluginFolder)"/>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(KSPModRoot)/$(KSPModPluginFolder)/%(RecursiveDir)"/>
+    <MakeDir Directories="$(KSPBTModRoot)/$(KSPBTModPluginFolder)"/>
+    <Copy SourceFiles="@(_BinariesToCopy)" DestinationFolder="$(KSPBTModRoot)/$(KSPBTModPluginFolder)/%(RecursiveDir)"/>
   </Target>
 
   <!-- Use CKAN to install mods for any references tagged with a CKAN Identifier -->
@@ -45,14 +45,14 @@
       <_CKANDependency Include="@(CKANDependency)"/>
     </ItemGroup>
     <PropertyGroup>
-      <CKANDependencyList>@(_CKANDependency, ' ')</CKANDependencyList>
+      <_CKANDependencyList>@(_CKANDependency, ' ')</_CKANDependencyList>
     </PropertyGroup>
     <ItemGroup>
       <!-- Not using `ckan compat set` because as of 2024-08-16 it is still only available in the dev branch -->
-      <_CKANCommands Include="compat add --gamedir &quot;$(KSPROOT)&quot; %(_CKANCompatibleVersionItems.Identity)"
+      <_CKANCommands Include="compat add --gamedir &quot;$(KSPBTGameRoot)&quot; %(_CKANCompatibleVersionItems.Identity)"
                      Condition=" '$(CKANCompatibleVersions)' != '' "/>
 
-      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPROOT)&quot; $(CKANDependencyList)" Condition="'$(CKANDependencyList)' != ''"/>
+      <_CKANCommands Include="install --no-recommends --gamedir &quot;$(KSPBTGameRoot)&quot; $(_CKANDependencyList)" Condition="'$(CKANDependencyList)' != ''"/>
     </ItemGroup>
     <Message Text="Writing CKAN commands to $(CKANCommandFile)"/>
     <Message Text="@(_CKANCommands, '%0a')" Importance="Low"/>
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <!-- Execute generated CKAN command list -->
-  <Target Name="CKANInstall" DependsOnTargets="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences" Inputs="$(CKANCommandFile)" Outputs="$(KSPRoot)/CKAN/registry.json">
+  <Target Name="CKANInstall" DependsOnTargets="CKANInstallScriptGen" BeforeTargets="_GenerateRestoreProjectSpec;Restore;ResolveAssemblyReferences" Inputs="$(CKANCommandFile)" Outputs="$(KSPBTGameRoot)/CKAN/registry.json">
     <Exec Command="ckan prompt --headless &lt; '$(CKANCommandFile)'" Condition="'$(CKANDependencyList)' != ''"/>
   </Target>
 
@@ -82,8 +82,8 @@
   </Target>
 
   <!-- Generate the KSPAssembly attribute based on the FileVersion property -->
-  <Target Name="GenerateKSPAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition="'$(GenerateKSPAssemblyAttribute)' == 'true'">
+  <Target Name="KSPBTGenerateAssemblyAttribute" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition="'$(KSPBTGenerateAssemblyAttribute)' == 'true'">
     <ItemGroup>
       <AssemblyAttribute Include="KSPAssembly">
         <_Parameter1>$(AssemblyName)</_Parameter1>
@@ -106,8 +106,8 @@
     Otherwise CKANVersion is used.
     Otherwise 0.0 is used (no minimum version)
   -->
-  <Target Name="GenerateKSPAssemblyDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
-          Condition=" '$(GenerateKSPAssemblyDependencyAttributes)' == 'true' ">
+  <Target Name="KSPBTGenerateDependencyAttributes" BeforeTargets="CoreGenerateAssemblyInfo"
+          Condition=" '$(KSPBTGenerateDependencyAttributes)' == 'true' ">
     <ItemGroup>
       <Reference Update="%(Reference.identity)" Condition="'%(Reference.CKANIdentifier)%(Reference.KSPAssemblyName)' != ''">
         <KSPAssemblyName Condition="'%(Reference.KSPAssemblyName)' == ''">$([System.String]::Copy('%(Reference.identity)').Split(',')[0])</KSPAssemblyName>
@@ -153,9 +153,9 @@
   </ItemDefinitionGroup>
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
-  <Target Name="GenerateKSPVersionFile" AfterTargets="Build"
+  <Target Name="KSPBTGenerateVersionFile" AfterTargets="Build"
           Inputs="@(KSPVersionFile);$(FileVersion)" Outputs="%(KSPVersionFile.destination)"
-          Condition= " '$(GenerateKSPVersionFile)' == 'true' ">
+          Condition= " '$(KSPBTGenerateVersionFile)' == 'true' ">
     <ItemGroup>
       <KSPVersionFile Update="@(KSPVersionFile)">
         <Name Condition="'%(KSPVersionFile.Name)' == ''">$(ProjectName)</Name>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,6 +2,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
+  <!-- Calculate KSPBT_ManagedPath -->
+  <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
+    <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>
+  </PropertyGroup>
+
   <!-- Import references -->
   <ItemGroup Condition=" '$(KSPBT_ReferenceSystemAssemblies)' == 'true' ">
     <Reference Include="$(KSPBT_ManagedPath)/System.dll">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' != 'true' ">
+  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' == 'true' ">
     <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <!-- Instruct the compiler to not automatically reference mscorlib -->

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,6 +2,51 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
+  <!-- Relative path that must exist for a path to be a valid KSP Install-->
+  <PropertyGroup>
+    <KSPBT_GameIdentifier>$(KSPBT_ManagedRelativePath)/Assembly-CSharp.dll</KSPBT_GameIdentifier>
+    <KSPBT_GameRootSource Condition="'$(KSPBT_GameRoot)' != ''">property</KSPBT_GameRootSource>
+  </PropertyGroup>
+
+  <!-- Default KSPBT_GameRoot to the "KSP_ROOT" environment variable if it exists -->
+  <!-- Doing this skips any checks for a valid KSP install so be careful! -->
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And '$(KSP_ROOT)' != '' ">
+    <KSPBT_GameRoot>$(KSP_ROOT)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>environment variable</KSPBT_GameRootSource>
+  </PropertyGroup>
+  <ItemGroup>
+    <KSPBT_GameRootCandidate Include="$(SolutionDir)KSP" source="solution directory"/>
+    <KSPBT_GameRootCandidate Include="$(ReferencePath)" source="reference path"/>
+    <KSPBT_GameRootCandidate Include="$(_KSPBT_SteamGameRoot)" source="steam"/>
+  </ItemGroup>
+
+  <!-- Look for KSP install in Solution dir -->
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(SolutionDir)KSP/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(SolutionDir)KSP</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>solution directory</KSPBT_GameRootSource>
+  </PropertyGroup>
+
+  <!-- Look for KSP install in ReferencePath -->
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(ReferencePath)/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(ReferencePath)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>reference path</KSPBT_GameRootSource>
+  </PropertyGroup>
+
+  <!-- Look for KSP steam install-->
+  <PropertyGroup Condition=" '$(KSPBT_GameRoot)' == '' And Exists('$(_KSPBT_SteamGameRoot)/$(KSPBT_GameIdentifier)') ">
+    <KSPBT_GameRoot>$(_KSPBT_SteamGameRoot)</KSPBT_GameRoot>
+    <KSPBT_GameRootSource>steam</KSPBT_GameRootSource>
+  </PropertyGroup>
+
+  <!-- set the start action so that you can launch directly from VS -->
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(KSPBT_GameRoot)/$(_KSPBT_GameExecutable)</StartProgram>
+    <StartWorkingDirectory>$(KSPBT_GameRoot)</StartWorkingDirectory>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+
   <!-- Calculate KSPBT_ManagedPath -->
   <PropertyGroup Condition=" '$(KSPBT_ManagedPath)' == ''">
     <KSPBT_ManagedPath>$(KSPBT_GameRoot)/$(KSPBT_ManagedRelativePath)</KSPBT_ManagedPath>

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -243,13 +243,7 @@
     </ItemGroup>
   </Target>
 
-  <ItemDefinitionGroup>
-    <KSPVersionFile>
-      <KSP_Version>1.12</KSP_Version>
-      <KSP_Version_Min>1.8</KSP_Version_Min>
-      <KSP_Version_Max>1.12</KSP_Version_Max>
-    </KSPVersionFile>
-  </ItemDefinitionGroup>
+
 
   <!-- Target to generate the KSP version json file for AVC/CKAN etc-->
   <Target Name="KSPBT_GenerateVersionFile" AfterTargets="Build"

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -2,20 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition=" '$(KSPCommonPropsImported)' == '' And Exists('$(MSBuildThisFileDirectory)KSPCommon.props') " Project="$(MSBuildThisFileDirectory)KSPCommon.props"/>
 
-  <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
-    <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Instruct the compiler to not automatically reference mscorlib -->
-    <NoStandardLib>true</NoStandardLib>
-    <!-- Prevent the GetReferenceAssemblyPaths task in Microsoft.Common.CurrentVersion.targets
-         from attempting to locate an external copy of the reference assemblies. -->
-    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <FrameworkPathOverride>$(KSPBTManagedPath)</FrameworkPathOverride>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-
-
   <!-- Import references -->
   <ItemGroup Condition=" '$(KSPBTReferenceSystemAssemblies)' == 'true' ">
     <Reference Include="$(KSPBTManagedPath)/System.dll">

--- a/KSPCommon.targets
+++ b/KSPCommon.targets
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <!-- Prevent the compiler from acquiring or referencing any external reference assemblies -->
-  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' != 'true' ">>
+  <PropertyGroup Condition=" '$(ReferenceKSPSystemAssemblies)' != 'true' ">
     <!-- Do not download the .NET Framework Target Pack NuGet package automatically -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <!-- Instruct the compiler to not automatically reference mscorlib -->

--- a/docs/msbuild/configuration.md
+++ b/docs/msbuild/configuration.md
@@ -1,10 +1,6 @@
-# MSBuild Items And Properties
+# Configuration
 
 ## Properties
-
-```{confval} KSPBT_GameRoot
-This property should be set to the root directory of your KSP install. You should not set this in your csproj, see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
-```
 
 ```{confval} KSPBT_ModRoot
 ---
@@ -71,3 +67,10 @@ default: `true`
 ---
 If set to `true`, adds references to the assemblies included in `ModReference` list.
 ```
+
+````{confval} KSPBT_GameRoot
+```{warning}
+You should **not** set or use this property in your csproj file.
+```
+This property should be set to the root directory of your KSP install. see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
+````

--- a/docs/msbuild/configuration.md
+++ b/docs/msbuild/configuration.md
@@ -26,20 +26,6 @@ default: `1.12 1.11 1.10 1.9 1.8`
 Used by the `CKANInstall` target to set additional KSP versions to treat as compatible when installing 
 ```
 
-```{confval} KSPBT_GenerateAssemblyAttribute
----
-default: `true`
----
-If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.
-```
-
-```{confval} KSPBT_GenerateDependencyAttributes
----
-default: `true`
----
-If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. 
-```
-
 ```{confval} KSPBT_ReferenceSystemAssemblies
 ---
 default: `true`
@@ -56,16 +42,44 @@ If set to `true`, adds assembly references to all UnityEngine assemblies in the 
 
 ```{confval} KSPBT_ReferenceGameAssemblies
 ---
-default: `true`
+default: `true`, except in the `Unity` configuration
 ---
 If set to `true`, adds references to Assembly-CSharp and Assembly-CSharp-firstpass assemblies from the KSP install.
 ```
 
 ```{confval} KSPBT_ReferenceModAssemblies
 ---
-default: `true`
+default: `true`, except in the `Unity` configuration
 ---
 If set to `true`, adds references to the assemblies included in `ModReference` list.
+```
+
+```{confval} KSPBT_GenerateAssemblyAttribute
+---
+default: `true`, except in the `Unity` configuration
+---
+If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.
+```
+
+```{confval} KSPBT_GenerateDependencyAttributes
+---
+default: `true`, except in the `Unity` configuration
+---
+If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. 
+```
+
+```{confval} KSPBT_CopyDLLsToPluginFolder
+---
+default: `true`, except in the `Unity` configuration
+---
+If set to `true`, automatically copies the compiled DLL to the {confval}`KSPBT_ModPluginFolder`.
+```
+
+```{confval} KSPBT_GenerateVersionFile
+---
+default: `true`, except in the `Unity` configuration
+---
+If set to `true`, automatically generates a version file using the information in any {confval}`KSPVersionFile` items. Without defining a {confval}`KSPVersionFile`, nothing will be generated. See [](generating-version-files.md/) for more details. 
 ```
 
 ````{confval} KSPBT_GameRoot
@@ -73,4 +87,89 @@ If set to `true`, adds references to the assemblies included in `ModReference` l
 You should **not** set or use this property in your csproj file.
 ```
 This property should be set to the root directory of your KSP install. see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
+````
+
+## Items
+
+````{confval} ModReference
+A reference to another mod that is a dependency. This mod will be automatically referenced in the build process and installed using CKAN if an identifier is given. See [](dependencies.md) for examples.
+
+```{rubric} Metadata
+```
+
+```{describe} Identity
+The name of the mod you are referencing, as set in that mod's `KSPAssemblyAttribute`
+```
+
+```{describe} DLLPath
+The path of the mod's assembly to reference when building, relative to {confval}`KSPBT_GameRoot`.
+```
+
+```{describe} CKANIdentifier
+The name of the mod in CKAN to install before building.
+```
+
+```{describe} CKANVersion
+The specific version to install from CKAN, if any.
+```
+
+Any additional metadata is copied to the resulting [`Reference`](https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#reference) item 
+````
+
+````{confval} KSPVersionFile
+Defines a version file to generate. See [](generating-version-files.md) for examples.
+
+```{rubric} Metadata
+```
+
+```{describe} Identity
+To create a new version file from scratch, set to `.`. Otherwise set to a path to a json version file to use as a base
+```
+```{describe} Destination
+Path to where the generated json version file should be placed
+```
+
+```{confval} Name
+---
+default: `$(ProjectName)`
+---
+The mod name. Corresponds to the `NAME` value in json.
+```
+
+```{confval} Version
+---
+default: `$(FileVersion)`
+---
+The mod version. Corresponds with the `VERSION` value in json.
+```
+
+```{describe} URL
+The URL of the remote version file. Corresponds with the `URL` value in json.
+```
+
+```{describe} Download
+Where to link players to update your mod. Corresponds with the `DOWNLOAD` value in json.
+```
+
+```{confval} KSP_Version
+---
+default: `1.12`
+---
+The KSP version the mod is targeting. Corresponds with the `KSP_VERSION` value in json.
+```
+
+```{confval} KSP_Version_Min
+---
+default: `1.8`
+---
+The minimum supported KSP version. Corresponds with the `KSP_VERSION_MIN` value in json.
+```
+
+```{confval} KSP_Version_Max
+---
+default: `1.12`
+---
+The maximum supported KSP version. Corresponds with the `KSP_VERSION_MAX` value in json.
+```
+
 ````

--- a/docs/msbuild/configuration.md
+++ b/docs/msbuild/configuration.md
@@ -1,10 +1,12 @@
-# MSBuild Properties
+# MSBuild Items And Properties
 
-```{confval} KSPBTGameRoot
+## Properties
+
+```{confval} KSPBT_GameRoot
 This property should be set to the root directory of your KSP install. You should not set this in your csproj, see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
 ```
 
-```{confval} KSPBTModRoot
+```{confval} KSPBT_ModRoot
 ---
 default: `$(MSBuildProjectDir)/../GameData/$(MSBuildProjectName)/`
 ---
@@ -12,15 +14,15 @@ default: `$(MSBuildProjectDir)/../GameData/$(MSBuildProjectName)/`
 specifies the root directory of your mod (the folder that gets placed into GameData).  Generally you'll want to set this to be relative to the csproj file using `$(MSBuildThisFileDirectory)`.
 ```
 
-```{confval} KSPBTModPluginFolder
+```{confval} KSPBT_ModPluginFolder
 ---
-default: `Plugins`
+default: `./`
 ---
 
-the directory where compiled binaries should be copied. This is relative to the `KSPBTMosRoot`. The DLLs will be copied to this directory after each build.
+the directory where compiled binaries should be copied. This is relative to the {confval}`KSPBT_ModRoot`. The DLLs will be copied to this directory after each build.
 ```
 
-```{confval} CKANCompatibleVersions
+```{confval} KSPBT_CKANCompatibleVersions
 ---
 default: `1.12 1.11 1.10 1.9 1.8`
 ---
@@ -28,37 +30,44 @@ default: `1.12 1.11 1.10 1.9 1.8`
 Used by the `CKANInstall` target to set additional KSP versions to treat as compatible when installing 
 ```
 
-```{confval} KSPBTGenerateAssemblyAttribute
+```{confval} KSPBT_GenerateAssemblyAttribute
 ---
 default: `true`
 ---
 If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.
 ```
 
-```{confval} KSPBTGenerateDependencyAttributes
+```{confval} KSPBT_GenerateDependencyAttributes
 ---
 default: `true`
 ---
 If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. 
 ```
 
-```{confval} KSPBTReferenceSystemAssemblies
+```{confval} KSPBT_ReferenceSystemAssemblies
 ---
 default: `true`
 ---
 If set to `true`, adds assembly references to Mono System DLLs.
 ```
 
-```{confval} KSPBTReferenceUnityAssemblies
+```{confval} KSPBT_ReferenceUnityAssemblies
 ---
 default: `true`
 ---
-If set to `true`, adds assembly references to all UnityEngine assemblies in the KSP install.  You can set this to `false` to opt out of this behavior if you want to create a pure C# assembly that does not depend on Unity.
+If set to `true`, adds assembly references to all UnityEngine assemblies in the KSP install. 
 ```
 
-```{confval} KSPBTReferenceGameAssemblies
+```{confval} KSPBT_ReferenceGameAssemblies
 ---
 default: `true`
 ---
-If set to `true`, adds references to Assembly-CSharp and Assembly-CSharp-firstpass assemblies from the KSP install.  You can set this to `false` to opt out of this behavior.
+If set to `true`, adds references to Assembly-CSharp and Assembly-CSharp-firstpass assemblies from the KSP install.
+```
+
+```{confval} KSPBT_ReferenceModAssemblies
+---
+default: `true`
+---
+If set to `true`, adds references to the assemblies included in `ModReference` list.
 ```

--- a/docs/msbuild/dependencies.md
+++ b/docs/msbuild/dependencies.md
@@ -66,10 +66,23 @@ The version is taken from the `<KSPAssemblyVersion>` metadata value, however lea
 ```xml
 <ItemGroup>
   <!-- Depends on Tweakscale -->
-  <Reference Include="Scale">
+  <ModReference Include="Scale">
     <DLLPath>GameData/TweakScale/plugins/Scale.dll</DLLPath>
     <CKANIdentifier>TweakScaleRescaled</CKANIdentifier>
     <KSPAssemblyVersion>3.2.0</KSPAssemblyVersion>
-  </Reference>
+  </ModReference>
+</ItemGroup>
+```
+
+To disable generating the `KSPAssemblyDependency` attribute for a single dependency (for example, if it lacks the `KSPAssembly` attribute), you can set `GenerateDependencyAttribute` to false
+
+```xml
+<ItemGroup>
+  <!-- Depends on Tweakscale, but without the `KSPAssemblyDependency` attribute -->
+  <ModReference Include="Scale">
+    <DLLPath>GameData/TweakScale/plugins/Scale.dll</DLLPath>
+    <CKANIdentifier>TweakScaleRescaled</CKANIdentifier>
+    <GenerateDependencyAttribute>false</GenerateDependencyAttribute>
+  </ModReference>
 </ItemGroup>
 ```

--- a/docs/msbuild/dependencies.md
+++ b/docs/msbuild/dependencies.md
@@ -6,15 +6,15 @@ KSPBuildTools can help manage other mods that you depend on
 
 Mod DLLs should be referenced as with any other DLLs, like so. See [the Microsoft docs on Reference items](https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#reference) for more info. Make sure that `<Private>False</Private>`{l=xml} is set or the DLL will be copied to your output directory.
 
-the {confval}`KSPRoot` property can be used to reference the KSP install wherever it is. 
+the {confval}`KSPBTGameRoot` property can be used to reference the KSP install wherever it is. 
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager and Harmony -->
-  <Reference Include="$(KSPRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
     <Private>False</Private>
   </Reference>
   <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-    <HintPath>$(KSPRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+    <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
     <Private>False</Private>
   </Reference>
 </ItemGroup>
@@ -27,7 +27,7 @@ KSPBuildTools can install CKAN mods automatically when built. This is useful for
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager -->
-  <Reference Include="$(KSPRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
     <Private>False</Private>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
   </Reference>
@@ -42,7 +42,7 @@ You can also mark explicit versions to install.
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager 4.2.3 ONLY -->
-  <Reference Include="$(KSPRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
     <Private>False</Private>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
     <CKANVersion>4.2.3</CKANVersion>
@@ -59,7 +59,7 @@ KSP mods should mark their dependency DLLs using the `KSPAssemblyDependency` att
 
 `[assembly: KSPAssemblyDependency("0Harmony", 0, 0, 0)]`{l=csharp}
 
-If the {confval}`GenerateKSPAssemblyDependencyAttributes` property is set to `true`, KSPBuildTools will generate these attributes automatically. It uses any `Reference` item that has a `<CKANIdentifier>` or `<KSPAssemblyName>` metadata value.
+If the {confval}`KSPBTGenerateDependencyAttributes` property is set to `true`, KSPBuildTools will generate these attributes automatically. It uses any `Reference` item that has a `<CKANIdentifier>` or `<KSPAssemblyName>` metadata value.
 
 The assembly name is set to the `<KSPAssemblyName>` metadata value, and falls back to the `<CKANIdentifier>` metadata value. 
 
@@ -68,7 +68,7 @@ The version is taken from the `<KSPAssemblyVersion>` metadata value, however lea
 ```xml
 <ItemGroup>
   <!-- Depends on Tweakscale -->
-  <Reference Include="$(KSPRoot)/GameData/TweakScale/plugins/Scale.dll">
+  <Reference Include="$(KSPBTGameRoot)/GameData/TweakScale/plugins/Scale.dll">
     <Private>False</Private>
     <CKANIdentifier>TweakScaleRescaled</CKANIdentifier>
     <KSPAssemblyName>Scale</KSPAssemblyName>
@@ -78,7 +78,7 @@ The version is taken from the `<KSPAssemblyVersion>` metadata value, however lea
 
 <PropertyGroup>
   <!-- Generate assembly attributes -->
-  <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
-  <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
+  <KSPBTGenerateAssemblyAttribute>true</KSPBTGenerateAssemblyAttribute>
+  <KSPBTGenerateDependencyAttributes>true</KSPBTGenerateDependencyAttributes>
 </PropertyGroup>
 ```

--- a/docs/msbuild/dependencies.md
+++ b/docs/msbuild/dependencies.md
@@ -6,15 +6,15 @@ KSPBuildTools can help manage other mods that you depend on
 
 Mod DLLs should be referenced as with any other DLLs, like so. See [the Microsoft docs on Reference items](https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#reference) for more info. Make sure that `<Private>False</Private>`{l=xml} is set or the DLL will be copied to your output directory.
 
-the {confval}`KSPBTGameRoot` property can be used to reference the KSP install wherever it is. 
+the {confval}`KSPBT_GameRoot` property can be used to reference the KSP install wherever it is. 
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager and Harmony -->
-  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
     <Private>False</Private>
   </Reference>
   <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-    <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+    <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
     <Private>False</Private>
   </Reference>
 </ItemGroup>
@@ -27,7 +27,7 @@ KSPBuildTools can install CKAN mods automatically when built. This is useful for
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager -->
-  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
     <Private>False</Private>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
   </Reference>
@@ -42,7 +42,7 @@ You can also mark explicit versions to install.
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager 4.2.3 ONLY -->
-  <Reference Include="$(KSPBTGameRoot)/Modulemanager*.dll">
+  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
     <Private>False</Private>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
     <CKANVersion>4.2.3</CKANVersion>
@@ -59,7 +59,7 @@ KSP mods should mark their dependency DLLs using the `KSPAssemblyDependency` att
 
 `[assembly: KSPAssemblyDependency("0Harmony", 0, 0, 0)]`{l=csharp}
 
-If the {confval}`KSPBTGenerateDependencyAttributes` property is set to `true`, KSPBuildTools will generate these attributes automatically. It uses any `Reference` item that has a `<CKANIdentifier>` or `<KSPAssemblyName>` metadata value.
+If the {confval}`KSPBT_GenerateDependencyAttributes` property is set to `true`, KSPBuildTools will generate these attributes automatically. It uses any `Reference` item that has a `<CKANIdentifier>` or `<KSPAssemblyName>` metadata value.
 
 The assembly name is set to the `<KSPAssemblyName>` metadata value, and falls back to the `<CKANIdentifier>` metadata value. 
 
@@ -68,7 +68,7 @@ The version is taken from the `<KSPAssemblyVersion>` metadata value, however lea
 ```xml
 <ItemGroup>
   <!-- Depends on Tweakscale -->
-  <Reference Include="$(KSPBTGameRoot)/GameData/TweakScale/plugins/Scale.dll">
+  <Reference Include="$(KSPBT_GameRoot)/GameData/TweakScale/plugins/Scale.dll">
     <Private>False</Private>
     <CKANIdentifier>TweakScaleRescaled</CKANIdentifier>
     <KSPAssemblyName>Scale</KSPAssemblyName>
@@ -78,7 +78,7 @@ The version is taken from the `<KSPAssemblyVersion>` metadata value, however lea
 
 <PropertyGroup>
   <!-- Generate assembly attributes -->
-  <KSPBTGenerateAssemblyAttribute>true</KSPBTGenerateAssemblyAttribute>
-  <KSPBTGenerateDependencyAttributes>true</KSPBTGenerateDependencyAttributes>
+  <KSPBT_GenerateAssemblyAttribute>true</KSPBT_GenerateAssemblyAttribute>
+  <KSPBT_GenerateDependencyAttributes>true</KSPBT_GenerateDependencyAttributes>
 </PropertyGroup>
 ```

--- a/docs/msbuild/dependencies.md
+++ b/docs/msbuild/dependencies.md
@@ -4,33 +4,31 @@ KSPBuildTools can help manage other mods that you depend on
 
 ## Referencing Dependency DLLs
 
-Mod DLLs should be referenced as with any other DLLs, like so. See [the Microsoft docs on Reference items](https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#reference) for more info. Make sure that `<Private>False</Private>`{l=xml} is set or the DLL will be copied to your output directory.
+Mod DLLs should be referenced with the {confval}`ModReference` item, like so. 
 
-the {confval}`KSPBT_GameRoot` property can be used to reference the KSP install wherever it is. 
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager and Harmony -->
-  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-    <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
+  <ModReference Include="Modulemanager">
+    <DLLPath>GameData/Modulemanager*.dll</DLLPath>
+  </ModReference>
+  <ModReference Include="0Harmony">
+    <DLLPath>GameData/000_Harmony/0Harmony.dll</DLLPath>
+  </ModReference>
 </ItemGroup>
 ```
 
 ## Installing Dependencies Automatically
 
-KSPBuildTools can install CKAN mods automatically when built. This is useful for CI workflows such as those using the {gha:action}`compile` action, or to make it easier for others to compile your mod themselves. Either add the `<CKANIdentifier>` metadata to your `<Reference>` items, or if the dependency mod doesn't have a dll you need to reference you can use the `<CKANDependency>` item.
+KSPBuildTools can install CKAN mods automatically when built. This is useful for CI workflows such as those using the {gha:action}`compile` action, or to make it easier for others to compile your mod themselves. Either add the `<CKANIdentifier>` metadata to your `<ModReference>` items, or if the dependency mod doesn't have a dll you need to reference you can use the `<CKANDependency>` item.
 
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager -->
-  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
-    <Private>False</Private>
+  <ModReference Include="Modulemanager">
+    <DLLPath>GameData/Modulemanager*.dll</DLLPath>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
-  </Reference>
+  </ModReference>
   
   <!-- Also depends on Tantares SP, which doesn't have a plugin -->
   <CKANDependency Include="TantaresSP"/>
@@ -42,11 +40,11 @@ You can also mark explicit versions to install.
 ```xml
 <ItemGroup>
   <!-- Depends on Modulemanager 4.2.3 ONLY -->
-  <Reference Include="$(KSPBT_GameRoot)/Modulemanager*.dll">
-    <Private>False</Private>
+  <ModReference Include="Modulemanager">
+    <DLLPath>GameData/Modulemanager*.dll</DLLPath>
     <CKANIdentifier>ModuleManager</CKANIdentifier>
     <CKANVersion>4.2.3</CKANVersion>
-  </Reference>
+  </ModReference>
   
   <!-- Also depends on Tantares SP, which doesn't have a plugin -->
   <CKANDependency Include="TantaresSP==6.0"/>
@@ -59,26 +57,19 @@ KSP mods should mark their dependency DLLs using the `KSPAssemblyDependency` att
 
 `[assembly: KSPAssemblyDependency("0Harmony", 0, 0, 0)]`{l=csharp}
 
-If the {confval}`KSPBT_GenerateDependencyAttributes` property is set to `true`, KSPBuildTools will generate these attributes automatically. It uses any `Reference` item that has a `<CKANIdentifier>` or `<KSPAssemblyName>` metadata value.
+If the {confval}`KSPBT_GenerateDependencyAttributes` property is set to `true` (the default), KSPBuildTools will generate these attributes automatically.
 
-The assembly name is set to the `<KSPAssemblyName>` metadata value, and falls back to the `<CKANIdentifier>` metadata value. 
+The assembly name is taken from the value of the item.
 
 The version is taken from the `<KSPAssemblyVersion>` metadata value, however leaving it at the default of 0.0.0 is usually acceptable
 
 ```xml
 <ItemGroup>
   <!-- Depends on Tweakscale -->
-  <Reference Include="$(KSPBT_GameRoot)/GameData/TweakScale/plugins/Scale.dll">
-    <Private>False</Private>
+  <Reference Include="Scale">
+    <DLLPath>GameData/TweakScale/plugins/Scale.dll</DLLPath>
     <CKANIdentifier>TweakScaleRescaled</CKANIdentifier>
-    <KSPAssemblyName>Scale</KSPAssemblyName>
     <KSPAssemblyVersion>3.2.0</KSPAssemblyVersion>
   </Reference>
 </ItemGroup>
-
-<PropertyGroup>
-  <!-- Generate assembly attributes -->
-  <KSPBT_GenerateAssemblyAttribute>true</KSPBT_GenerateAssemblyAttribute>
-  <KSPBT_GenerateDependencyAttributes>true</KSPBT_GenerateDependencyAttributes>
-</PropertyGroup>
 ```

--- a/docs/msbuild/generating-version-files.md
+++ b/docs/msbuild/generating-version-files.md
@@ -8,7 +8,7 @@ To use, add the following to your csproj, filling in the URLs and paths for your
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include=".">
-    <Destination>$(RepoRootPath)GameData/MyMod/mymod.version</Destination>
+    <Destination>$(KSPModRoot)/mymod.version</Destination>
     <URL>https://github.com/username/repo/releases/latest/download/mymod.version</URL>
     <Download>https://github.com/username.repo/releases/latest</Download>
   </KSPVersionFile>
@@ -44,7 +44,7 @@ The `include` value can also be set to a json file including any other values yo
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include="my-mod.version">
-    <Destination>$(RepoRootPath)GameData/MyMod/mymod.version</Destination>
+    <Destination>$(KSPModRoot)/mymod.version</Destination>
   </KSPVersionFile>
 </ItemGroup>
 ```

--- a/docs/msbuild/generating-version-files.md
+++ b/docs/msbuild/generating-version-files.md
@@ -8,7 +8,7 @@ To use, add the following to your csproj, filling in the URLs and paths for your
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include=".">
-    <Destination>$(KSPModRoot)/mymod.version</Destination>
+    <Destination>$(KSPBTModRoot)/mymod.version</Destination>
     <URL>https://github.com/username/repo/releases/latest/download/mymod.version</URL>
     <Download>https://github.com/username.repo/releases/latest</Download>
   </KSPVersionFile>
@@ -44,7 +44,7 @@ The `include` value can also be set to a json file including any other values yo
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include="my-mod.version">
-    <Destination>$(KSPModRoot)/mymod.version</Destination>
+    <Destination>$(KSPBTModRoot)/mymod.version</Destination>
   </KSPVersionFile>
 </ItemGroup>
 ```

--- a/docs/msbuild/generating-version-files.md
+++ b/docs/msbuild/generating-version-files.md
@@ -8,7 +8,7 @@ To use, add the following to your csproj, filling in the URLs and paths for your
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include=".">
-    <Destination>$(KSPBTModRoot)/mymod.version</Destination>
+    <Destination>$(KSPBT_ModRoot)/mymod.version</Destination>
     <URL>https://github.com/username/repo/releases/latest/download/mymod.version</URL>
     <Download>https://github.com/username.repo/releases/latest</Download>
   </KSPVersionFile>
@@ -44,7 +44,7 @@ The `include` value can also be set to a json file including any other values yo
 <!-- Version Files -->
 <ItemGroup>
   <KSPVersionFile Include="my-mod.version">
-    <Destination>$(KSPBTModRoot)/mymod.version</Destination>
+    <Destination>$(KSPBT_ModRoot)/mymod.version</Destination>
   </KSPVersionFile>
 </ItemGroup>
 ```

--- a/docs/msbuild/getting-started.md
+++ b/docs/msbuild/getting-started.md
@@ -74,9 +74,9 @@ KSPBuildTools needs to know where you have KSP installed in order to reference t
 
 There are several options for this. KSPBuildTools will choose in the following order. Either [autodiscovery in the solution directory](#solution-directory) or [setting a reference path in a .user file](#environment-variable) are the recommended methods for most users.
 
-### KSPRoot MSBuild Property
+### KSPBTGameRoot MSBuild Property
 
-If the {confval}`KSPRoot` MSBuild property is already set, KSPBuildTools will use it as-is. This can be set in your .csproj.user file.
+If the {confval}`KSPBTGameRoot` MSBuild property is already set, KSPBuildTools will use it as-is. This can be set in your .csproj.user file.
 
 ### Environment Variable
 

--- a/docs/msbuild/getting-started.md
+++ b/docs/msbuild/getting-started.md
@@ -74,9 +74,9 @@ KSPBuildTools needs to know where you have KSP installed in order to reference t
 
 There are several options for this. KSPBuildTools will choose in the following order. Either [autodiscovery in the solution directory](#solution-directory) or [setting a reference path in a .user file](#environment-variable) are the recommended methods for most users.
 
-### KSPBTGameRoot MSBuild Property
+### KSPBT_GameRoot MSBuild Property
 
-If the {confval}`KSPBTGameRoot` MSBuild property is already set, KSPBuildTools will use it as-is. This can be set in your .csproj.user file.
+If the {confval}`KSPBT_GameRoot` MSBuild property is already set, KSPBuildTools will use it as-is. This can be set in your .csproj.user file.
 
 ### Environment Variable
 

--- a/docs/msbuild/index.md
+++ b/docs/msbuild/index.md
@@ -23,6 +23,6 @@ maxdepth: 1
 getting-started
 generating-version-files
 dependencies
-properties
+configuration
 ```
 

--- a/docs/msbuild/properties.md
+++ b/docs/msbuild/properties.md
@@ -4,20 +4,20 @@
 This property should be set to the root directory of your KSP install. You should not set this in your csproj, see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
 ```
 
-```{confval} RepoRootPath
+```{confval} KSPModRoot
 ---
-default: `$(SolutionDir)`
+default: `$(ProjectDir)/../GameData/$(ProjectName)/`
 ---
 
-specifies the root directory of your mod repository.  Generally you'll want to set this to be relative to the csproj file using `$(MSBuildThisFileDirectory)`.
+specifies the root directory of your mod (the folder that gets placed into GameData).  Generally you'll want to set this to be relative to the csproj file using `$(MSBuildThisFileDirectory)`.
 ```
 
-```{confval} BinariesOutputRelativePath
+```{confval} KSPModPluginFolder
 ---
-default: `GameData/$(SolutionName)`
+default: `$(KSPModRoot)/Plugins`
 ---
 
-the directory where compiled binaries should be copied.  This is relative to the `RepoRootPath`.  The binaries will be copied to this directory after each build.
+the directory where compiled binaries should be copied.  This is relative to the `KSPModRoot`.  The binaries will be copied to this directory after each build.
 ```
 
 ```{confval} CKANCompatibleVersions
@@ -36,14 +36,14 @@ If set to `true`, automatically generates the `KSPAssembly` for your assembly fr
 If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. 
 ```
 
-```{confval} ReferenceUnityAssemblies
+```{confval} ReferenceKSPUnityAssemblies
 ---
 default: `true`
 ---
 If set to `true`, adds assembly references to all UnityEngine assemblies in the KSP install.  You can set this to `false` to opt out of this behavior if you want to create a pure C# assembly that does not depend on Unity.
 ```
 
-```{confval} ReferenceKSPAssemblies
+```{confval} ReferenceKSPGameAssemblies
 ---
 default: `true`
 ---

--- a/docs/msbuild/properties.md
+++ b/docs/msbuild/properties.md
@@ -1,23 +1,23 @@
 # MSBuild Properties
 
-```{confval} KSPRoot
+```{confval} KSPBTGameRoot
 This property should be set to the root directory of your KSP install. You should not set this in your csproj, see [Locating your KSP Install](getting-started.md/#locating-your-ksp-install)
 ```
 
-```{confval} KSPModRoot
+```{confval} KSPBTModRoot
 ---
-default: `$(ProjectDir)/../GameData/$(ProjectName)/`
+default: `$(MSBuildProjectDir)/../GameData/$(MSBuildProjectName)/`
 ---
 
 specifies the root directory of your mod (the folder that gets placed into GameData).  Generally you'll want to set this to be relative to the csproj file using `$(MSBuildThisFileDirectory)`.
 ```
 
-```{confval} KSPModPluginFolder
+```{confval} KSPBTModPluginFolder
 ---
-default: `$(KSPModRoot)/Plugins`
+default: `Plugins`
 ---
 
-the directory where compiled binaries should be copied.  This is relative to the `KSPModRoot`.  The binaries will be copied to this directory after each build.
+the directory where compiled binaries should be copied. This is relative to the `KSPBTMosRoot`. The DLLs will be copied to this directory after each build.
 ```
 
 ```{confval} CKANCompatibleVersions
@@ -28,22 +28,35 @@ default: `1.12 1.11 1.10 1.9 1.8`
 Used by the `CKANInstall` target to set additional KSP versions to treat as compatible when installing 
 ```
 
-```{confval} GenerateKSPAssemblyAttribute
+```{confval} KSPBTGenerateAssemblyAttribute
+---
+default: `true`
+---
 If set to `true`, automatically generates the `KSPAssembly` for your assembly from the `Version` property.
 ```
 
-```{confval} GenerateKSPAssemblyDependencyAttributes
+```{confval} KSPBTGenerateDependencyAttributes
+---
+default: `true`
+---
 If set to `true`, automatically generates `KSPAssemblyDependency` attributes for each dependency. Dependencies should have either the `CKANIdentifier` metadata or `KSPAssemblyName` metadata. Versions can be supplied with `CKANVersion` or `KSPAssemblyVersion`. 
 ```
 
-```{confval} ReferenceKSPUnityAssemblies
+```{confval} KSPBTReferenceSystemAssemblies
+---
+default: `true`
+---
+If set to `true`, adds assembly references to Mono System DLLs.
+```
+
+```{confval} KSPBTReferenceUnityAssemblies
 ---
 default: `true`
 ---
 If set to `true`, adds assembly references to all UnityEngine assemblies in the KSP install.  You can set this to `false` to opt out of this behavior if you want to create a pure C# assembly that does not depend on Unity.
 ```
 
-```{confval} ReferenceKSPGameAssemblies
+```{confval} KSPBTReferenceGameAssemblies
 ---
 default: `true`
 ---

--- a/tests/plugin-mod-legacy/PluginModLegacy/plugin-mod-legacy.csproj
+++ b/tests/plugin-mod-legacy/PluginModLegacy/plugin-mod-legacy.csproj
@@ -50,10 +50,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <RepoRootPath>$(MSBuildThisFileDirectory)../</RepoRootPath>
-    <BinariesOutputRelativePath>GameData/plugin-mod-legacy</BinariesOutputRelativePath>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)/$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <Import Project="$(MSBuildThisFileDirectory)../../../KSPCommon.targets" />
   <Import Project="$(MSBuildBinPath)/Microsoft.CSharp.targets" />

--- a/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
@@ -23,13 +23,13 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
-    <KSPBTModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBTModRoot>
+    <KSPBT_ModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBT_ModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
   <ItemGroup>
     <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+      <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
       <Private>False</Private>
@@ -39,7 +39,7 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(KSPBTModRoot)/plugin-mod-nuget.version</Destination>
+      <Destination>$(KSPBT_ModRoot)/plugin-mod-nuget.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
 </Project>

--- a/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
@@ -28,12 +28,12 @@
 
   <!-- DLL Dependencies-->
   <ItemGroup>
-    <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+    <ModReference Include="0Harmony">
+      <DLLPath>GameData/000_Harmony/0Harmony.dll</DLLPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
       <Private>False</Private>
-    </Reference>
+    </ModReference>
   </ItemGroup>
 
   <!-- Version Files -->

--- a/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod-nuget.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <KSPBuildToolsVersion Condition = " '$(KSPBuildToolsVersion)' == ''">*-*</KSPBuildToolsVersion>
+    <RootNamespace>plugin-mod</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/plugin-mod-nuget/plugin-mod.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod.csproj
@@ -22,13 +22,13 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPModRoot>
+    <KSPBTModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBTModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
   <ItemGroup>
     <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+      <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
       <Private>False</Private>
@@ -38,7 +38,7 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(KSPModRoot)/plugin-mod-nuget.version</Destination>
+      <Destination>$(KSPBTModRoot)/plugin-mod-nuget.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
 </Project>

--- a/tests/plugin-mod-nuget/plugin-mod.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod.csproj
@@ -22,7 +22,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)</KSPModRoot>
+    <KSPModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->

--- a/tests/plugin-mod-nuget/plugin-mod.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod.csproj
@@ -22,8 +22,6 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)GameData/plugin-mod-nuget/</KSPModRoot>
-    <KSPModPluginFolder>$(KSPModRoot)/</KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->

--- a/tests/plugin-mod-nuget/plugin-mod.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod.csproj
@@ -22,8 +22,8 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
-    <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
-    <BinariesOutputRelativePath>GameData/plugin-mod-nuget</BinariesOutputRelativePath>
+    <KSPModRoot>$(MSBuildThisFileDirectory)GameData/plugin-mod-nuget/</KSPModRoot>
+    <KSPModPluginFolder>$(KSPModRoot)/</KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
@@ -39,12 +39,7 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(RepoRootPath)$(BinariesOutputRelativePath)/plugin-mod-nuget.version</Destination>
+      <Destination>$(KSPModRoot)/plugin-mod-nuget.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
-  
-  <PropertyGroup>
-    <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
-    <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
-  </PropertyGroup>
 </Project>

--- a/tests/plugin-mod-nuget/plugin-mod.csproj
+++ b/tests/plugin-mod-nuget/plugin-mod.csproj
@@ -22,6 +22,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginModNuget</AssemblyName>
+    <KSPModRoot>$(MSBuildThisFileDirectory)</KSPModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -6,6 +6,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="JsonPoke" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Static Properties -->
@@ -22,12 +26,11 @@
 
   <!-- DLL Dependencies-->
   <ItemGroup>
-    <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+    <ModReference Include="0Harmony">
+      <DLLPath>GameData/000_Harmony/0Harmony.dll</DLLPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
-      <Private>False</Private>
-    </Reference>
+    </ModReference>
   </ItemGroup>
 
   <!-- Version Files -->

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,8 +17,8 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
-    <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
-    <BinariesOutputRelativePath>GameData/plugin-mod</BinariesOutputRelativePath>
+    <KSPModRoot>$(MSBuildThisFileDirectory)GameData/plugin-mod/</KSPModRoot>
+    <KSPModPluginFolder>$(KSPModRoot)/</KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
@@ -34,14 +34,9 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(RepoRootPath)$(BinariesOutputRelativePath)/plugin-mod.version</Destination>
+      <Destination>$(KSPModRoot)/plugin-mod.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
   
-  <PropertyGroup>
-    <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
-    <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)../../KSPCommon.targets" />
 </Project>

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,8 +17,6 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)GameData/plugin-mod/</KSPModRoot>
-    <KSPModPluginFolder>$(KSPModRoot)/</KSPModPluginFolder>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,13 +17,13 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
-    <KSPBTModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBTModRoot>
+    <KSPBT_ModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBT_ModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
   <ItemGroup>
     <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+      <HintPath>$(KSPBT_GameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
       <Private>False</Private>
@@ -33,7 +33,7 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(KSPBTModRoot)/plugin-mod.version</Destination>
+      <Destination>$(KSPBT_ModRoot)/plugin-mod.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
   

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,7 +17,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)</KSPModRoot>
+    <KSPModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,13 +17,13 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
-    <KSPModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPModRoot>
+    <KSPBTModRoot>$(MSBuildThisFileDirectory)/GameData/$(MSBuildProjectName)</KSPBTModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->
   <ItemGroup>
     <Reference Include="0Harmony, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(KSPRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
+      <HintPath>$(KSPBTGameRoot)/GameData/000_Harmony/0Harmony.dll</HintPath>
       <CKANIdentifier>Harmony2</CKANIdentifier>
       <CKANVersion>2.2.1.0</CKANVersion>
       <Private>False</Private>
@@ -33,7 +33,7 @@
   <!-- Version Files -->
   <ItemGroup>
     <KSPVersionFile Include=".">
-      <Destination>$(KSPModRoot)/plugin-mod.version</Destination>
+      <Destination>$(KSPBTModRoot)/plugin-mod.version</Destination>
     </KSPVersionFile>
   </ItemGroup>
   

--- a/tests/plugin-mod/plugin-mod.csproj
+++ b/tests/plugin-mod/plugin-mod.csproj
@@ -17,6 +17,7 @@
     <NoWarn>1701;1702;CS0649;CS1591;</NoWarn>
     <AssemblyCopyright>2024 KSPModdingLibs Contributors</AssemblyCopyright>
     <AssemblyName>PluginMod</AssemblyName>
+    <KSPModRoot>$(MSBuildThisFileDirectory)</KSPModRoot>
   </PropertyGroup>
 
   <!-- DLL Dependencies-->


### PR DESCRIPTION
This is a breaking change (so the version would change to 0.1.0 or even 1.0.0).

The goals here were:
* eliminating the double-import of the .csproj.user file. Instead, this branch means that the path to KSP root never gets referenced in the user .csproj at all, allowing all the path determination to be calculated at runtime
* eliminating risk of namespace-collision with other frameworks for property names
* allowing toggling each component of KSPBT, to account for weird use cases, such as...
* allowing building mods for use in the Unity editor, such as UI code, by automatically disabling all the references that are unsafe there. Its up to the mod developer still to set up preprocessor directives and includes to allow compilation in this situation, but it eliminates any need for keeping code the same between the main mod codebase and "stub" cs files just to get serialization working

Changelog: 
- Renamed global msbuild properties to have the `KSPBT_` prefix to avoid namespace collisions with other frameworks
  - `KSPRoot` is now `KSPBT_GameRoot`. It should no longer be referenced within a .csproj file
  - `RepoRootPath` is now `KSPBT_ModRoot`, and should now point to the mod folder within GameData rather than the
    root of a git repo
  - `BinariesOutputRelativePath` is now `KSPBT_ModPluginFolder`
  - `GenerateKSPAssemblyAttribute` is now `KSPBT_GenerateAssemblyAttribute` and defaults to true
  - `GenerateKSPAssemblyDependencyAttributes` is now `KSPBT_GenerateDependencyAttributes` and defaults to true
  - `ReferenceUnityAssemblies` is now `KSPBT_ReferenceUnityAssemblies`
  - `ReferenceKSPAssemblies` is now `KSPBT_ReferenceGameAssemblies`
- Added the `KSPBT_ReferenceSystemAssemblies` property to control referencing the mono system DLLs within the KSP
  managed folder. Setting this property to false will load the implicit framework DLLs instead.
- Mod dependencies should now be declared with
  `ModReference` items. This avoids the need for the KSP install path to be known at evaluation time.

