### PR TITLE
Update `create-release` with some extra options

### DIFF
--- a/.github/actions/assemble-release/action.yml
+++ b/.github/actions/assemble-release/action.yml
@@ -19,7 +19,7 @@ inputs:
 
   flatten:
     description: If `true`, the zip is built with the artifact files at the root instead of nested under a top-level `output-file-name` directory. Use this when consumers expect to extract the archive directly into a target directory (e.g. `GameData/`, `LICENSE`, etc. at the root of the zip).
-    default: "false"
+    default: "true"
 
   working-directory:
     default: ${{ github.workspace }}

--- a/.github/actions/assemble-release/action.yml
+++ b/.github/actions/assemble-release/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Output artifact name used in the upload-artifact action WITHOUT ".zip" extension. a zip file with this name will be created in the github workspace so that it can be immediately consumed by other actions in the workflow without having to download the artifact.
     default: ${{ github.event.repository.name || 'release'}}
 
+  flatten:
+    description: If `true`, the zip is built with the artifact files at the root instead of nested under a top-level `output-file-name` directory. Use this when consumers expect to extract the archive directly into a target directory (e.g. `GameData/`, `LICENSE`, etc. at the root of the zip).
+    default: "false"
+
   working-directory:
     default: ${{ github.workspace }}
     description: The working directory to run in
@@ -63,6 +67,10 @@ runs:
       shell: bash
       working-directory: ${{ env.RELEASE_STAGING }}
       run: |
-        zip -r ${{ inputs.output-file-name }}.zip ${{ inputs.output-file-name}}
+        if [ '${{ inputs.flatten }}' = 'true' ]; then
+          (cd '${{ inputs.output-file-name }}' && zip -9 -r '../${{ inputs.output-file-name }}.zip' .)
+        else
+          zip -9 -r '${{ inputs.output-file-name }}.zip' '${{ inputs.output-file-name }}'
+        fi
         echo 'artifact-zip-path=${{ env.RELEASE_STAGING }}/${{ inputs.output-file-name }}.zip' >> $GITHUB_OUTPUT
         echo 'artifact-dir-path=${{ env.RELEASE_STAGING }}/${{ inputs.output-file-name}}' >> $GITHUB_OUTPUT

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,20 @@ on:
       artifacts:
         type: string
         default: GameData LICENSE* README* CHANGELOG*
+      flatten:
+        type: boolean
+        default: false
+        description: >
+          If true, the release zip is built with the artifact files at the root
+          instead of nested under a top-level directory. Forwarded to the
+          assemble-release action.
+      version-file:
+        type: string
+        description: >
+          Path to a KSP-AVC `.version` file (relative to the repository root).
+          If set, the file is attached to the github release as a separate
+          asset alongside the assembled zip, so tools like CKAN's NetKAN can
+          read it without downloading the full archive.
       ksp-zip-url:
         type: string
         default: https://github.com/KSPModdingLibs/KSPLibs/raw/main/KSP-1.12.5.zip
@@ -105,10 +119,15 @@ jobs:
         with:
           artifacts: ${{ inputs.artifacts }}
           output-file-name: ${{ github.event.repository.name }}-${{ env.VERSION_STRING }}
+          flatten: ${{ inputs.flatten }}
 
       - name: create-release
         env:
           GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ZIP: ${{ steps.assemble-release.outputs.artifact-zip-path }}
+          VERSION_FILE: ${{ inputs.version-file }}
         run: |
           git push
-          gh release create "$VERSION_STRING" --draft --target ${{ github.ref_name }} --title "$VERSION_STRING" "${{ steps.assemble-release.outputs.artifact-zip-path }}" --notes-file "$RELEASE_NOTES_FILE"
+          assets=("$ARTIFACT_ZIP")
+          [ -n "$VERSION_FILE" ] && assets+=("$VERSION_FILE")
+          gh release create "$VERSION_STRING" --draft --target ${{ github.ref_name }} --title "$VERSION_STRING" --notes-file "$RELEASE_NOTES_FILE" "${assets[@]}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ on:
         default: GameData LICENSE* README* CHANGELOG*
       flatten:
         type: boolean
-        default: false
+        default: true
         description: >
           If true, the release zip is built with the artifact files at the root
           instead of nested under a top-level directory. Forwarded to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file
 
+## Unreleased
+
+### Workflows
+
+- `assemble-release` action: zip output now uses maximum compression (`-9`).
+- `assemble-release` action: new `flatten` input. When `true`, the artifact files are placed at the root of the zip instead of nested under a top-level `output-file-name` directory.
+- `create-release` workflow: forwards a new `flatten` input to `assemble-release`.
+- `create-release` workflow: new `version-file` input — path to a KSP-AVC `.version` file that should be attached to the github release as a separate asset alongside the assembled zip (for tools like CKAN's NetKAN).
+
+
 ## 1.1.1 - 2025-12-01
 
 ### Msbuild


### PR DESCRIPTION
This commit introduces some new options to the create-release workflow that can be used to control the exact paths in the output artifact.

The options are:
* `flatten` - Strip out the top level directory that the assemble-release action adds within the zip.
* `version-file` - Specify a version file to be uploaded to the release alongside the existing release artifact.